### PR TITLE
Nice parser error formatting in debug (-D hscriptPos) mode

### DIFF
--- a/Test.hx
+++ b/Test.hx
@@ -91,18 +91,17 @@ class Test {
 
 		#if hscriptPos
 			// If compiled with hscriptPos, expect a formatted parser error message:
-			//	Error: Parse error: EUnexpected()),	 on line 2, char 21-21
+			//	Uncaught exception - test.hscript.hx:2: characters 21-21 : EUnexpected())
 			//	> 1: var a=1; var b=2;
 			//	> 2: trace('a+b='+(a + b)));
 			//														^
 			//	> 3: trace('complete!');
-			//	> 4: 
+			//	> 4:
 
 			try {
 				test("var a=1; var b=2;\ntrace('a+b='+(a + b)));\ntrace('complete!');\n",true);
 			} catch (e:Dynamic) {
-				if ((e+'').indexOf("on line 2, char 21")<0) {
-					trace(e);
+				if ((e+'').indexOf("characters 21")<0) {
 					throw "Expected nicely formatted parse error message";
 				}
 			}

--- a/Test.hx
+++ b/Test.hx
@@ -84,7 +84,7 @@ class Test {
 		test("function bug(){ \n }\nbug().x", null);
 		test("1 + 2 == 3", true);
 		test("-2 == 3 - 5", true);
-    test("(true ? 6 : 999) - (false ? 333 : 1)",5);
+		test("(true ? 6 : 999) - (false ? 333 : 1)",5);
 
 		// Expect an interpreter error message with the name of the misspelled function
 		test("var msg=''; var obj = {}; obj.sum = function(a,b) return a + b; try { obj.sum_misspelled(1, 2); } catch (e:Dynamic) { msg = e+''; }; msg.indexOf('sum_misspelled')>=0",true);

--- a/Test.hx
+++ b/Test.hx
@@ -85,6 +85,10 @@ class Test {
 		test("1 + 2 == 3", true);
 		test("-2 == 3 - 5", true);
     test("(true ? 6 : 999) - (false ? 333 : 1)",5);
+
+		// Expect an interpreter error message with the name of the misspelled function
+		test("var msg=''; var obj = {}; obj.sum = function(a,b) return a + b; try { obj.sum_misspelled(1, 2); } catch (e:Dynamic) { msg = e+''; }; msg.indexOf('sum_misspelled')>=0",true);
+
 		trace("Done");
 	}
 

--- a/Test.hx
+++ b/Test.hx
@@ -89,6 +89,25 @@ class Test {
 		// Expect an interpreter error message with the name of the misspelled function
 		test("var msg=''; var obj = {}; obj.sum = function(a,b) return a + b; try { obj.sum_misspelled(1, 2); } catch (e:Dynamic) { msg = e+''; }; msg.indexOf('sum_misspelled')>=0",true);
 
+		#if hscriptPos
+			// If compiled with hscriptPos, expect a formatted parser error message:
+			//	Error: Parse error: EUnexpected()),	 on line 2, char 21-21
+			//	> 1: var a=1; var b=2;
+			//	> 2: trace('a+b='+(a + b)));
+			//														^
+			//	> 3: trace('complete!');
+			//	> 4: 
+
+			try {
+				test("var a=1; var b=2;\ntrace('a+b='+(a + b)));\ntrace('complete!');\n",true);
+			} catch (e:Dynamic) {
+				if ((e+'').indexOf("on line 2, char 21")<0) {
+					trace(e);
+					throw "Expected nicely formatted parse error message";
+				}
+			}
+		#end
+
 		trace("Done");
 	}
 

--- a/Test.hx
+++ b/Test.hx
@@ -84,6 +84,7 @@ class Test {
 		test("function bug(){ \n }\nbug().x", null);
 		test("1 + 2 == 3", true);
 		test("-2 == 3 - 5", true);
+    test("(true ? 6 : 999) - (false ? 333 : 1)",5);
 		trace("Done");
 	}
 

--- a/hscript/Bytes.hx
+++ b/hscript/Bytes.hx
@@ -130,7 +130,7 @@ class Bytes {
 	}
 
 	function doEncode( exp : Expr ) {
-    var e = #if hscriptPos exp.e #else exp #end;
+		var e = #if hscriptPos exp.e #else exp #end;
 		bout.addByte(Type.enumIndex(e));
 		switch( e ) {
 		case EConst(c):
@@ -224,8 +224,7 @@ class Bytes {
 	}
 
 	function doDecode() : Expr {
-		var e =
-      switch( bin.get(pin++) ) {
+		var e = switch( bin.get(pin++) ) {
 		case 0:
 			EConst( doDecodeConst() );
 		case 1:
@@ -317,7 +316,7 @@ class Bytes {
 			throw "Invalid code "+bin.get(pin - 1);
 		}
 
-    return #if hscriptPos { e : e, pmin : 0, pmax : 0 } #else e #end;
+		return #if hscriptPos { e : e, pmin : 0, pmax : 0 } #else e #end;
 	}
 
 	public static function encode( e : Expr ) : haxe.io.Bytes {

--- a/hscript/Bytes.hx
+++ b/hscript/Bytes.hx
@@ -307,6 +307,8 @@ class Bytes {
 				fl.push({ name : name, e : e });
 			}
 			EObject(fl);
+		case 22:
+			ETernary(doDecode(),doDecode(),doDecode());
 		case 255:
 			null;
 		default:

--- a/hscript/Bytes.hx
+++ b/hscript/Bytes.hx
@@ -129,7 +129,8 @@ class Bytes {
 		}
 	}
 
-	function doEncode( e : Expr ) {
+	function doEncode( exp : Expr ) {
+    var e = #if hscriptPos exp.e #else exp #end;
 		bout.addByte(Type.enumIndex(e));
 		switch( e ) {
 		case EConst(c):
@@ -223,7 +224,8 @@ class Bytes {
 	}
 
 	function doDecode() : Expr {
-		return switch( bin.get(pin++) ) {
+		var e =
+      switch( bin.get(pin++) ) {
 		case 0:
 			EConst( doDecodeConst() );
 		case 1:
@@ -314,6 +316,8 @@ class Bytes {
 		default:
 			throw "Invalid code "+bin.get(pin - 1);
 		}
+
+    return #if hscriptPos { e : e, pmin : 0, pmax : 0 } #else e #end;
 	}
 
 	public static function encode( e : Expr ) : haxe.io.Bytes {

--- a/hscript/Interp.hx
+++ b/hscript/Interp.hx
@@ -61,9 +61,9 @@ class Interp {
 		initOps();
 	}
 
-  #if hscriptPos
+	#if hscriptPos
 	public inline function error( err:ErrorDef, pmin:Int, pmax:Int ) {
-    var msg = untyped ("Error: Interpreter error: "+err+", char "+pmin+"-"+pmax);
+		var msg = untyped ("Error: Interpreter error: "+err+", char "+pmin+"-"+pmax);
 		throw msg;
 		throw err;
 	}
@@ -116,7 +116,7 @@ class Interp {
 
 	function assign( e1 : Expr, e2 : Expr ) : Dynamic {
 		var v = expr(e2);
-    switch( #if hscriptPos e1.e #else e1 #end ) {
+		switch( #if hscriptPos e1.e #else e1 #end ) {
 		case EIdent(id):
 			var l = locals.get(id);
 			if( l == null )
@@ -139,7 +139,7 @@ class Interp {
 
 	function evalAssignOp(op,fop,e1,e2) : Dynamic {
 		var v;
-    switch( #if hscriptPos e1.e #else e1 #end ) {
+		switch( #if hscriptPos e1.e #else e1 #end ) {
 		case EIdent(id):
 			var l = locals.get(id);
 			v = fop(expr(e1),expr(e2));
@@ -163,7 +163,7 @@ class Interp {
 	}
 
 	function increment( e : Expr, prefix : Bool, delta : Int ) : Dynamic {
-      switch( #if hscriptPos e.e #else e #end ) {
+		switch( #if hscriptPos e.e #else e #end ) {
 		case EIdent(id):
 			var l = locals.get(id);
 			var v : Dynamic = (l == null) ? variables.get(id) : l.r;
@@ -248,13 +248,13 @@ class Interp {
 	}
 
 	public function expr( e : Expr ) : Dynamic {
-    if (e==null) return null;
-    #if hscriptPos
-      if (e.e==null) return null;
-  		switch( e.e ) {
-    #else
-  		switch( e ) {
-    #end
+		if (e==null) return null;
+		#if hscriptPos
+			if (e.e==null) return null;
+			switch( e.e ) {
+		#else
+			switch( e ) {
+		#end
 		case EConst(c):
 			switch( c ) {
 			case CInt(v): return v;
@@ -308,7 +308,7 @@ class Interp {
 			var args = new Array();
 			for( p in params )
 				args.push(expr(p));
-      switch( #if hscriptPos e.e #else e #end ) {
+			switch( #if hscriptPos e.e #else e #end ) {
 			case EField(e,f):
 				var obj = expr(e);
 				if( obj == null ) error(EInvalidAccess(f), 0, 0);

--- a/hscript/Interp.hx
+++ b/hscript/Interp.hx
@@ -457,7 +457,11 @@ class Interp {
 	}
 
 	function fcall( o : Dynamic, f : String, args : Array<Dynamic> ) : Dynamic {
-		return call(o, Reflect.field(o, f), args);
+		var call_o = Reflect.field(o, f);
+		if (call_o==null) {
+			error(EInvalidAccess(f), 0, 0);
+		}
+		return call(o, call_o, args);
 	}
 	
 	function call( o : Dynamic, f : Dynamic, args : Array<Dynamic> ) : Dynamic {

--- a/hscript/Interp.hx
+++ b/hscript/Interp.hx
@@ -61,14 +61,17 @@ class Interp {
 		initOps();
 	}
 
+  #if hscriptPos
 	public inline function error( err:ErrorDef, pmin:Int, pmax:Int ) {
-		#if hscriptPos
     var msg = untyped ("Error: Interpreter error: "+err+", char "+pmin+"-"+pmax);
 		throw msg;
-		#else
 		throw err;
-		#end
 	}
+	#else
+	public inline function error( err:Error, pmin:Int, pmax:Int ) {
+		throw err;
+	}
+	#end
 
 	function initOps() {
 		var me = this;

--- a/hscript/Parser.hx
+++ b/hscript/Parser.hx
@@ -130,9 +130,9 @@ class Parser {
 			unops.set(x, x == "++" || x == "--");
 	}
 
-  #if hscriptPos
+	#if hscriptPos
 	public inline function error( err:ErrorDef, pmin:Int, pmax:Int ) {
-    var msg = untyped ("Error: Parse error: "+err+", char "+pmin+"-"+pmax);
+		var msg = untyped ("Error: Parse error: "+err+", char "+pmin+"-"+pmax);
 		throw msg;
 		throw err;
 	}
@@ -1054,42 +1054,42 @@ class Parser {
 	}
 
 	static private function formatParseError(msg:String, prog:String):String
-  {
-    var r = ~/char ([0-9]+)\-([0-9]+)/;
-    if (r.match(msg)) {
-      var error = "";
-      var char = Std.parseInt(r.matched(1));
-      var end = Std.parseInt(r.matched(1));
-   
-      var lines = prog.split("\n");
-      var line = 1;
-      var bbfor = "";
-      var before = "";
-      while (lines[0].length < char) {
-        bbfor = before;
-        before = lines.shift();
-        char -= before.length+1;
-        end -= before.length+1;
-        line++;
-      }
-      error += (r.replace(msg, "")+" on line "+line+", char "+char+"-"+end+"\n");
-      if (bbfor.length>0) { error += ("> "+(line-2)+": "+bbfor+"\n"); }
-      if (before.length>0) { error += ("> "+(line-1)+": "+before+"\n"); }
-      error += ("> "+(line)+": "+lines[0]+"\n");
-      var cnt = (line+":").length + char;
-      var spacer = " ";
-      while (cnt>0) {
-        spacer += " ";
-        cnt--;
-      }
-      error += ("  "+spacer+"^"+"\n");
-      if (lines.length>1) { error += ("> "+(line+1)+": "+lines[1]+"\n"); }
-      if (lines.length>2) { error += ("> "+(line+2)+": "+lines[2]+"\n"); }
+	{
+		var r = ~/char ([0-9]+)\-([0-9]+)/;
+		if (r.match(msg)) {
+			var error = "";
+			var char = Std.parseInt(r.matched(1));
+			var end = Std.parseInt(r.matched(1));
+	 
+			var lines = prog.split("\n");
+			var line = 1;
+			var bbfor = "";
+			var before = "";
+			while (lines[0].length < char) {
+				bbfor = before;
+				before = lines.shift();
+				char -= before.length+1;
+				end -= before.length+1;
+				line++;
+			}
+			error += (r.replace(msg, "")+" on line "+line+", char "+char+"-"+end+"\n");
+			if (bbfor.length>0) { error += ("> "+(line-2)+": "+bbfor+"\n"); }
+			if (before.length>0) { error += ("> "+(line-1)+": "+before+"\n"); }
+			error += ("> "+(line)+": "+lines[0]+"\n");
+			var cnt = (line+":").length + char;
+			var spacer = " ";
+			while (cnt>0) {
+				spacer += " ";
+				cnt--;
+			}
+			error += ("	 "+spacer+"^"+"\n");
+			if (lines.length>1) { error += ("> "+(line+1)+": "+lines[1]+"\n"); }
+			if (lines.length>2) { error += ("> "+(line+2)+": "+lines[2]+"\n"); }
 
-      return error;
-    } else {
-      return msg;
-    }
-  }
+			return error;
+		} else {
+			return msg;
+		}
+	}
 
 }

--- a/hscript/Parser.hx
+++ b/hscript/Parser.hx
@@ -130,14 +130,17 @@ class Parser {
 			unops.set(x, x == "++" || x == "--");
 	}
 
+  #if hscriptPos
 	public inline function error( err:ErrorDef, pmin:Int, pmax:Int ) {
-		#if hscriptPos
     var msg = untyped ("Error: Parse error: "+err+", char "+pmin+"-"+pmax);
 		throw msg;
-		#else
 		throw err;
-		#end
 	}
+	#else
+	public inline function error( err:Error, pmin:Int, pmax:Int ) {
+		throw err;
+	}
+	#end
 
 	public function invalidChar(c) {
 		error(EInvalidChar(c), readPos, readPos);

--- a/hscript/Parser.hx
+++ b/hscript/Parser.hx
@@ -130,9 +130,10 @@ class Parser {
 			unops.set(x, x == "++" || x == "--");
 	}
 
-	public inline function error( err, pmin, pmax ) {
+	public inline function error( err:ErrorDef, pmin:Int, pmax:Int ) {
 		#if hscriptPos
-		throw new Error(err, pmin, pmax);
+    var msg = untyped ("Error: Parse error: "+err+", char "+pmin+"-"+pmax);
+		throw msg;
 		#else
 		throw err;
 		#end

--- a/hscript/Parser.hx
+++ b/hscript/Parser.hx
@@ -132,9 +132,8 @@ class Parser {
 
 	#if hscriptPos
 	public inline function error( err:ErrorDef, pmin:Int, pmax:Int ) {
-		var msg = untyped ("Error: Parse error: "+err+", char "+pmin+"-"+pmax);
+		var msg = untyped (err+", char "+pmin+"-"+pmax);
 		throw msg;
-		throw err;
 	}
 	#else
 	public inline function error( err:Error, pmin:Int, pmax:Int ) {
@@ -146,14 +145,14 @@ class Parser {
 		error(EInvalidChar(c), readPos, readPos);
 	}
 
-	public function parseString( s : String ) {
+	public function parseString( s:String, debugFilename:String='[hscript]', debugVerbose:Bool=false ) {
 		line = 1;
 		#if hscriptPos
 		try {
 	 		var parsed = parse( new haxe.io.StringInput(s) );
 			return parsed;
 		} catch (e:Dynamic) {
-			throw formatParseError(e, s);
+			throw formatParseError(e, s, debugFilename, debugVerbose);
 		}
 		#else
 		return parse( new haxe.io.StringInput(s) );
@@ -1053,9 +1052,9 @@ class Parser {
 		}
 	}
 
-	static private function formatParseError(msg:String, prog:String):String
+	static private function formatParseError(msg:String, prog:String, debugFilename:String='[hscript]', debugVerbose:Bool=false):String
 	{
-		var r = ~/char ([0-9]+)\-([0-9]+)/;
+		var r = ~/, char ([0-9]+)\-([0-9]+)/;
 		if (r.match(msg)) {
 			var error = "";
 			var char = Std.parseInt(r.matched(1));
@@ -1072,7 +1071,9 @@ class Parser {
 				end -= before.length+1;
 				line++;
 			}
-			error += (r.replace(msg, "")+" on line "+line+", char "+char+"-"+end+"\n");
+			error += debugFilename+":"+line+": characters "+char+"-"+end+" : "+(r.replace(msg, ""));
+      if (!debugVerbose) return error;
+      error += "\n";
 			if (bbfor.length>0) { error += ("> "+(line-2)+": "+bbfor+"\n"); }
 			if (before.length>0) { error += ("> "+(line-1)+": "+before+"\n"); }
 			error += ("> "+(line)+": "+lines[0]+"\n");

--- a/hscript/Parser.hx
+++ b/hscript/Parser.hx
@@ -1082,7 +1082,7 @@ class Parser {
 				spacer += " ";
 				cnt--;
 			}
-			error += ("	 "+spacer+"^"+"\n");
+			error += ("  "+spacer+"^"+"\n");
 			if (lines.length>1) { error += ("> "+(line+1)+": "+lines[1]+"\n"); }
 			if (lines.length>2) { error += ("> "+(line+2)+": "+lines[2]+"\n"); }
 


### PR DESCRIPTION
I've fixed up the debug compile (-D hscriptPos) mode, ensured that character numbers are properly passed through all errors, and added a nice formatting function to the Parser.

In hscriptPos mode only, the Parser's `parseString` function now will throw errors formatted like this:

```
Error: Parse error: EUnexpected()),  on line 2, char 21-21
> 1: var a=1; var b=2;
> 2: trace('a+b='+(a + b)));
                          ^
> 3: trace('complete!');
> 4: 
```

Prior to this, it was **_very**_ difficult to track down syntax errors, especially in multi-line scripts, where error messages were simply:

```
Error: Parse error: EUnexpected())
```

This happens to encompass my previous pull request (ternary operator support, 7535030), as well as a fix (92224f62353) that throws EInvalidAccess when a referenced function is missing from an object -- instead of a useless error message thrown later about a null reference when trying to call null()

I've added test cases into `Test.hx` for all fixes.
