### PR TITLE
tried adding a  hscriptMandatoryVar switch

### DIFF
--- a/hscript/Interp.hx
+++ b/hscript/Interp.hx
@@ -112,10 +112,28 @@ class Interp {
 		switch( edef(e1) ) {
 		case EIdent(id):
 			var l = locals.get(id);
-			if( l == null )
-				variables.set(id,v)
-			else
-				l.r = v;
+			if( l == null ){
+				#if hscriptMandatoryVar
+				if (variables.get(id)!=null){
+					variables.set(id,v);
+				} else {
+					error(EUnknownVariable(id));
+				}
+				#else
+				variables.set(id,v);
+				#end
+			}
+			else {
+ 				#if hscriptMandatoryVar
+				if (l.r!=null){
+					l.r = v;	
+				} else {
+					error(EUnknownVariable(id));
+				}
+				#else
+				l.r = v;	
+				#end
+			}
 		case EField(e,f):
 			v = set(expr(e),f,v);
 		case EArray(e,index):


### PR DESCRIPTION
Tried adding a switch hscriptMandatoryVar to require explicit global variable declaration. I found it confusing to be able to have global variables declared inside functions. E.g. the following has a value of 3:

    function f(){
        x=2;
    } 
    f();
    x+1;

I found that it was a bit confusing to have two different ways of declaring global variables - with and without var, so I've tried adding a flag to throw an error when you try to assign to a variable that you haven't explicitly declared.

I'm not 100% sure that my change does what I want to do.

 EIdent (which I guess is the bit I'm looking for) appears along with variables.set and locals.get(id).set in many places. I've just #if'd them in one place (assign()) and not many others:

expr (in EFunction - I'm ok with functions being declared as global variables in the regular way, so this is probably ok)
evalAssignOp (I don't understand how to call this)
increment (I don't think it's necessary here, because in the main branch you get an error right now if you it's an undeclared variable)  

I'm also not sure about the second #if,

    		#if hscriptMandatoryVar
		if (l.r!=null){
			l.r = v;	
		} else {
			error(EUnknownVariable(id));
		}
		#else
		l.r = v;	
		#end

 replacing what used to be just 

    l.r = v;

Regardless of accepting this or not, if you know what bits I should/shouldn't be modifying to achieve the desired affect, I'd very much appreciate it if you could let me know if there are any places I should be making these checks outside of.

Best,

S