### PR TITLE
Fix EBlock issue in expr()

### DIFF
--- a/hscript/Interp.hx
+++ b/hscript/Interp.hx
@@ -59,6 +59,7 @@ class Interp {
 		variables = new Hash();
 		locals = new Hash();
 		#end
+		declared = new Array();
 		variables.set("null",null);
 		variables.set("true",true);
 		variables.set("false",false);


### PR DESCRIPTION
`declared` was uninitialized if you didn't call `execute()` before `expr()`. This caused an error when an EBlock was parsed in `expr()`.

Used to be
```haxe
interp = new Interp();
interp.execute(parser.parseString("null")); // without calling execute first, there is an error
interp.expr(parser.parseString("i = 0; i++"));
```
But now
```haxe
interp = new Interp();
interp.expr(parser.parseString("i = 0; i++")); // works as intended
```