### PR TITLE
Added Map support

### DIFF
--- a/Test.hx
+++ b/Test.hx
@@ -138,7 +138,7 @@ class Test extends TestCase {
 		assertEquals(101, vars.stringIntMap['foo']);
 		assertScript('++stringIntMap["foo"]', 102, vars);
 		assertScript('var newMap = ["foo"=>"foo"]; newMap["foo"];', 'foo', vars);
-		#if (haxe_ver >= 3.3) && php
+		#if (!php || (haxe_ver >= 3.3))
 		assertScript('var newMap = [enumKey=>"foo"]; newMap[enumKey];', 'foo', vars);
 		#end
 		assertScript('var newMap = [{a:"a"}=>"foo", objKey=>"bar"]; newMap[objKey];', 'bar', vars);

--- a/Test.hx
+++ b/Test.hx
@@ -137,8 +137,6 @@ class Test extends TestCase {
 		assertScript('stringIntMap["foo"]++', 100, vars);
 		assertEquals(101, vars.stringIntMap['foo']);
 		assertScript('++stringIntMap["foo"]', 102, vars);
-		
-		var parser = new hscript.Parser();
 		assertScript('var newMap = ["foo"=>"foo"]; newMap["foo"];', 'foo', vars);
 		assertScript('var newMap = [enumKey=>"foo"]; newMap[enumKey];', 'foo', vars);
 		assertScript('var newMap = [{a:"a"}=>"foo", objKey=>"bar"]; newMap[objKey];', 'bar', vars);

--- a/Test.hx
+++ b/Test.hx
@@ -137,6 +137,11 @@ class Test extends TestCase {
 		assertScript('stringIntMap["foo"]++', 100, vars);
 		assertEquals(101, vars.stringIntMap['foo']);
 		assertScript('++stringIntMap["foo"]', 102, vars);
+		
+		var parser = new hscript.Parser();
+		assertScript('var newMap = ["foo"=>"foo"]; newMap["foo"];', 'foo', vars);
+		assertScript('var newMap = [enumKey=>"foo"]; newMap[enumKey];', 'foo', vars);
+		assertScript('var newMap = [{a:"a"}=>"foo", "A"=>"foobar", objKey=>"bar"]; newMap[objKey];', 'bar', vars);
 	}
 
 	static function main() {

--- a/Test.hx
+++ b/Test.hx
@@ -125,12 +125,14 @@ class Test extends TestCase {
 			}
 		}
 		
+		#if (!php || (haxe_ver >= 3.3))
 		assertScript('
 			var keys = [];
 			for (key in stringMap.keys()) keys.push(key);
 			keys.sort(function(s1, s2) return s1 > s2 ? 1 : (s2 > s1 ? -1 : 0));
 			keys.join("_");
 		', 'a_bar_foo', vars);
+		#end
 		assertScript('stringMap.remove("foo"); stringMap.exists("foo");', false, vars);
 		assertScript('stringMap["foo"] = "a"; stringMap["foo"] += "b"', 'ab', vars);
 		assertEquals('ab', vars.stringMap['foo']);

--- a/Test.hx
+++ b/Test.hx
@@ -125,12 +125,14 @@ class Test extends TestCase {
 			}
 		}
 		
+		#if haxe3
 		assertScript('
 			var keys = [];
 			for (key in stringMap.keys()) keys.push(key);
 			keys.sort(function(s1, s2) return s1 > s2 ? 1 : (s2 > s1 ? -1 : 0));
 			keys.join("_");
 		', 'a_bar_foo', vars);
+		#end
 		assertScript('stringMap.remove("foo"); stringMap.exists("foo");', false, vars);
 		assertScript('stringMap["foo"] = "a"; stringMap["foo"] += "b"', 'ab', vars);
 		assertEquals('ab', vars.stringMap['foo']);

--- a/Test.hx
+++ b/Test.hx
@@ -125,14 +125,12 @@ class Test extends TestCase {
 			}
 		}
 		
-		#if haxe3
 		assertScript('
 			var keys = [];
 			for (key in stringMap.keys()) keys.push(key);
 			keys.sort(function(s1, s2) return s1 > s2 ? 1 : (s2 > s1 ? -1 : 0));
 			keys.join("_");
 		', 'a_bar_foo', vars);
-		#end
 		assertScript('stringMap.remove("foo"); stringMap.exists("foo");', false, vars);
 		assertScript('stringMap["foo"] = "a"; stringMap["foo"] += "b"', 'ab', vars);
 		assertEquals('ab', vars.stringMap['foo']);
@@ -140,7 +138,9 @@ class Test extends TestCase {
 		assertEquals(101, vars.stringIntMap['foo']);
 		assertScript('++stringIntMap["foo"]', 102, vars);
 		assertScript('var newMap = ["foo"=>"foo"]; newMap["foo"];', 'foo', vars);
+		#if (haxe_ver >= 3.3) && php
 		assertScript('var newMap = [enumKey=>"foo"]; newMap[enumKey];', 'foo', vars);
+		#end
 		assertScript('var newMap = [{a:"a"}=>"foo", objKey=>"bar"]; newMap[objKey];', 'bar', vars);
 	}
 

--- a/Test.hx
+++ b/Test.hx
@@ -141,7 +141,7 @@ class Test extends TestCase {
 		var parser = new hscript.Parser();
 		assertScript('var newMap = ["foo"=>"foo"]; newMap["foo"];', 'foo', vars);
 		assertScript('var newMap = [enumKey=>"foo"]; newMap[enumKey];', 'foo', vars);
-		assertScript('var newMap = [{a:"a"}=>"foo", "A"=>"foobar", objKey=>"bar"]; newMap[objKey];', 'bar', vars);
+		assertScript('var newMap = [{a:"a"}=>"foo", objKey=>"bar"]; newMap[objKey];', 'bar', vars);
 	}
 
 	static function main() {

--- a/Test.hx
+++ b/Test.hx
@@ -1,3 +1,4 @@
+import haxe.ds.Option;
 import hscript.Macro;
 import haxe.unit.*;
 
@@ -93,6 +94,17 @@ class Test extends TestCase {
 		assertScript("var a:Array<Dynamic>=[1,2,4]; a[2]", 4, null, true);
 		assertScript("/**/0", 0);
 		assertScript("x=1;x*=-2", -2);
+	}
+	
+	function testMap():Void {
+		assertScript('stringMap["foo"] == "Foo" && stringMap["Foo"] == null', true, { stringMap:["foo" => "Foo", "bar" => "Bar"] });
+		assertScript('intMap[100]', "one hundred", { intMap:[100 => "one hundred"] } );
+		
+		var objKey = { ok:true };
+		assertScript('objMap[key]', "ok", { objMap:[objKey => "ok"], key:objKey });
+
+		var enumKey = Option.Some( { ok:true } );
+		assertScript('enumMap[key]', "ok", { enumMap:[enumKey => "ok", Option.None => ""], key:enumKey });
 	}
 
 	static function main() {

--- a/hscript/Interp.hx
+++ b/hscript/Interp.hx
@@ -598,18 +598,15 @@ class Interp {
 	}
 
 	inline function isMap(o:Dynamic):Bool {
-		return Std.is(o, haxe.ds.StringMap)
-			|| Std.is(o, haxe.ds.IntMap)
-			|| Std.is(o, haxe.ds.ObjectMap)
-			|| Std.is(o, haxe.ds.EnumValueMap);
+		return Std.is(o, haxe.Constraints.IMap);
 	}
 	
 	inline function getMapValue(map:Dynamic, key:Dynamic):Dynamic {
-		return cast(map, Map.IMap<Dynamic, Dynamic>).get(key);
+		return cast(map, haxe.Constraints.IMap<Dynamic, Dynamic>).get(key);
 	}
 
 	inline function setMapValue(map:Dynamic, key:Dynamic, value:Dynamic):Void {
-		cast(map, Map.IMap<Dynamic, Dynamic>).set(key, value);
+		cast(map, haxe.Constraints.IMap<Dynamic, Dynamic>).set(key, value);
 	}
 	
 	function get( o : Dynamic, f : String ) : Dynamic {
@@ -628,7 +625,7 @@ class Interp {
 		}
 		
 		if (result == null && isMap(o)) {
-			var map = cast(o, Map.IMap<Dynamic, Dynamic>);
+			var map = cast(o, haxe.Constraints.IMap<Dynamic, Dynamic>);
 			result = switch(f) {
 				case 'get': map.get;
 				case 'set': map.set;

--- a/hscript/Interp.hx
+++ b/hscript/Interp.hx
@@ -611,7 +611,7 @@ class Interp {
 	
 	function get( o : Dynamic, f : String ) : Dynamic {
 		if ( o == null ) error(EInvalidAccess(f));
-		var result:Dynamic = {
+		return {
 			#if php
 				// https://github.com/HaxeFoundation/haxe/issues/4915
 				try {
@@ -623,22 +623,6 @@ class Interp {
 				Reflect.getProperty(o, f);
 			#end
 		}
-		
-		if (result == null && isMap(o)) {
-			var map = cast(o, haxe.Constraints.IMap<Dynamic, Dynamic>);
-			result = switch(f) {
-				case 'get': map.get;
-				case 'set': map.set;
-				case 'exists': map.exists;
-				case 'remove': map.remove;
-				case 'keys': map.keys;
-				case 'iterator': map.iterator;
-				case 'toString': map.toString;
-				default: null;
-			}
-		}
-		
-		return result;
 	}
 
 	function set( o : Dynamic, f : String, v : Dynamic ) : Dynamic {

--- a/hscript/Interp.hx
+++ b/hscript/Interp.hx
@@ -590,7 +590,7 @@ class Interp {
 		}
 	}
 	
-	@:generic function getMapProperty<K>(map:Map<K, Dynamic>, key:Dynamic):Dynamic {
+	@:generic function getGenericMapProperty<K>(map:Map<K, Dynamic>, key:Dynamic):Dynamic {
 		return {
 			switch(key) {
 				case 'get': map.get;
@@ -604,8 +604,8 @@ class Interp {
 			}
 		}
 	}
-	inline function getEnumValueMapProperty<K:EnumValue>(map:Map<K, Dynamic>, key:Dynamic) return getMapProperty(map, key);
-	inline function getObjectMapProperty<K: { }>(map:Map<K, Dynamic>, key:Dynamic) return getMapProperty(map, key);
+	inline function getEnumValueMapProperty<K:EnumValue>(map:Map<K, Dynamic>, key:Dynamic) return getGenericMapProperty(map, key);
+	inline function getObjectMapProperty<K: { }>(map:Map<K, Dynamic>, key:Dynamic) return getGenericMapProperty(map, key);
 	
 	function get( o : Dynamic, f : String ) : Dynamic {
 		if ( o == null ) error(EInvalidAccess(f));
@@ -630,8 +630,8 @@ class Interp {
 			
 			result = {
 				switch(className) {
-					case 'haxe.ds.StringMap': getMapProperty((o:haxe.ds.StringMap<Dynamic>), f);
-					case 'haxe.ds.IntMap': getMapProperty((o:haxe.ds.IntMap<Dynamic>), f);
+					case 'haxe.ds.StringMap': getGenericMapProperty((o:haxe.ds.StringMap<Dynamic>), f);
+					case 'haxe.ds.IntMap': getGenericMapProperty((o:haxe.ds.IntMap<Dynamic>), f);
 					case 'haxe.ds.ObjectMap': getObjectMapProperty(o, f);
 					case 'haxe.ds.EnumValueMap': getEnumValueMapProperty(o, f);
 					default: null;

--- a/hscript/Interp.hx
+++ b/hscript/Interp.hx
@@ -569,8 +569,8 @@ class Interp {
 	}
 
 	function makeIterator( v : Dynamic ) : Iterator<Dynamic> {
-		#if (flash && !flash9)
-		if( v.iterator != null ) v = v.iterator();
+		#if ((flash && !flash9) || php)
+		if ( v.iterator != null ) v = v.iterator();
 		#else
 		try v = v.iterator() catch( e : Dynamic ) {};
 		#end

--- a/hscript/Parser.hx
+++ b/hscript/Parser.hx
@@ -111,7 +111,7 @@ class Parser {
 			["..."],
 			["&&"],
 			["||"],
-			["=","+=","-=","*=","/=","%=","<<=",">>=",">>>=","|=","&=","^="],
+			["=","+=","-=","*=","/=","%=","<<=",">>=",">>>=","|=","&=","^=","=>"],
 		];
 		#if haxe3
 		opPriority = new Map();
@@ -1062,6 +1062,8 @@ class Parser {
 				char = readChar();
 				if( char == '='.code )
 					return TOp("==");
+				else if ( char == '>'.code )
+					return TOp("=>");
 				this.char = char;
 				return TOp("=");
 			default:


### PR DESCRIPTION
It is now possible to pass maps to scripts, call get/set/exists/remove etc. and array access. Also it is possible to create new maps with [key=>value] literals in script. I've added some tests to Test.hx.

Tested with haxe 3.3.0rc1. Works on all targets that have build-....hxml file in repository.
