### PR TITLE
Fix compilation

### DIFF
--- a/hscript/Tools.hx
+++ b/hscript/Tools.hx
@@ -61,7 +61,7 @@ class Tools {
 	}
 
 	public static function map( e : Expr, f : Expr -> Expr ) {
-		var edef = switch( e.e ) {
+		var edef = switch( expr(e) ) {
 		case EConst(_), EIdent(_), EBreak, EContinue: expr(e);
 		case EVar(n, t, e): EVar(n, t, if( e != null ) f(e) else null);
 		case EParent(e): EParent(f(e));


### PR DESCRIPTION
This seems like an oversight form the changes in https://github.com/HaxeFoundation/hscript/commit/5bc357b4b3872d3c7e35b7943800d34fc3bfd809, without `hscriptPos`, compilation would fail with:

>hscript/hscript/Tools.hx:64: characters 22-25 : hscript.Expr has no field e