### PR TITLE
Call error() on invalid number of arguments instead of just throwing …

### DIFF
--- a/hscript/Interp.hx
+++ b/hscript/Interp.hx
@@ -360,7 +360,7 @@ class Interp {
 					if( args.length < minParams ) {
 						var str = "Invalid number of parameters. Got " + args.length + ", required " + minParams;
 						if( name != null ) str += " for function '" + name+"'";
-						error(EUnexpected(str));
+						error(ECustom(str));
 					}
 					// make sure mandatory args are forced
 					var args2 = [];

--- a/hscript/Interp.hx
+++ b/hscript/Interp.hx
@@ -360,7 +360,7 @@ class Interp {
 					if( args.length < minParams ) {
 						var str = "Invalid number of parameters. Got " + args.length + ", required " + minParams;
 						if( name != null ) str += " for function '" + name+"'";
-						throw str;
+						error(EUnexpected(str));
 					}
 					// make sure mandatory args are forced
 					var args2 = [];


### PR DESCRIPTION
With the hscriptPos flag, calls with argument count mismatches are not pinpointed. This fixes one that's troubled us.