### PR TITLE
Fix calling with 0 args targeting Java

### DIFF
--- a/hscript/Interp.hx
+++ b/hscript/Interp.hx
@@ -360,7 +360,7 @@ class Interp {
 					if( args.length < minParams ) {
 						var str = "Invalid number of parameters. Got " + args.length + ", required " + minParams;
 						if( name != null ) str += " for function '" + name+"'";
-						error(EUnexpected(str));
+						error(ECustom(str));
 					}
 					// make sure mandatory args are forced
 					var args2 = [];

--- a/hscript/Interp.hx
+++ b/hscript/Interp.hx
@@ -360,7 +360,7 @@ class Interp {
 					if( args.length < minParams ) {
 						var str = "Invalid number of parameters. Got " + args.length + ", required " + minParams;
 						if( name != null ) str += " for function '" + name+"'";
-						throw str;
+						error(EUnexpected(str));
 					}
 					// make sure mandatory args are forced
 					var args2 = [];

--- a/hscript/Interp.hx
+++ b/hscript/Interp.hx
@@ -356,7 +356,7 @@ class Interp {
 				else
 					minParams++;
 			var f = function(args:Array<Dynamic>) {
-				if( args.length != params.length ) {
+				if( ( (args == null) ? 0 : args.length ) != params.length ) {
 					if( args.length < minParams ) {
 						var str = "Invalid number of parameters. Got " + args.length + ", required " + minParams;
 						if( name != null ) str += " for function '" + name+"'";


### PR DESCRIPTION
With compiler 3.4.7, calling from Haxe to a Haxe script assigned callback fails when targeting Java because args is null. This is not a problem for js or hxcpp targets. This PR fixes it.