### PR TITLE
Disallow arbitrary operators in variable declaration

### DIFF
--- a/TestHScript.hx
+++ b/TestHScript.hx
@@ -125,7 +125,11 @@ class TestHScript extends TestCase {
 		assertScript("var a = 10; var b = 5; a - -b", 15);
 		assertScript("var a = 10; var b = 5; a - b / 2", 7.5);
 		assertScript("var a; a", null);
+		assertScript("var a = 1, b = 5; a + b;", 6);
 		assertScript("var a, b = 5; if (a == null) a = 2; a + b;", 7);
+		assertScript("var a:Int; a", null, null, true);
+		assertScript("var a:Int = 1, b:Int = 5; a + b;", 6, null, true);
+		assertScript("var a:Int, b:Int = 5; if (a == null) a = 2; a + b;", 7, null, true);
 		assertScript("false && xxx", false);
 		assertScript("true || xxx", true);
 		assertScript("[for( x in arr ) switch( x ) { case 1: 55; case 3: 66; default: 0; }].join(':')",'55:0:66',{ arr : [1,2,3] });

--- a/TestHScript.hx
+++ b/TestHScript.hx
@@ -124,6 +124,8 @@ class TestHScript extends TestCase {
 		assertScript("var f:(x:Int)->(Int, Int)->Int = (x:Int) -> (y:Int, z:Int) -> x + y + z; f(3)(1, 2)", 6, null, true);
 		assertScript("var a = 10; var b = 5; a - -b", 15);
 		assertScript("var a = 10; var b = 5; a - b / 2", 7.5);
+		assertScript("var a; a", null);
+		assertScript("var a, b = 5; if (a == null) a = 2; a + b;", 7);
 		assertScript("false && xxx", false);
 		assertScript("true || xxx", true);
 		assertScript("[for( x in arr ) switch( x ) { case 1: 55; case 3: 66; default: 0; }].join(':')",'55:0:66',{ arr : [1,2,3] });

--- a/hscript/Parser.hx
+++ b/hscript/Parser.hx
@@ -601,10 +601,14 @@ class Parser {
 				tk = token();
 			}
 			var e = null;
-			if( Type.enumEq(tk,TOp("=")) )
-				e = parseExpr();
-			else
-				push(tk);
+
+			switch (tk)
+			{
+				case TOp("="): e = parseExpr();
+				case TComma | TSemicolon: push(tk);
+				default: unexpected(tk);
+			}
+
 			mk(EVar(ident,t,e),p1,(e == null) ? tokenMax : pmax(e));
 		case "while":
 			var econd = parseExpr();


### PR DESCRIPTION
Added tests to check if `var x;` and `var a, b = X;` syntax was still working.

Closes #107 