### PR TITLE
Haxe Language Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /hscript.swf
 /release.zip
+
+bk/**

--- a/hscript/Bytes.hx
+++ b/hscript/Bytes.hx
@@ -190,7 +190,7 @@ class Bytes {
 			doEncode(it);
 			doEncode(e);
 		case EBreak, EContinue:
-		case EFunction(params,e,name,_):
+		case EFunction(Tools.getFunctionName(_) => name, {args: params,expr: e}):
 			bout.addByte(params.length);
 			for( p in params )
 				doEncodeString(p.name);
@@ -316,7 +316,7 @@ class Bytes {
 				params.push({ name : doDecodeString() });
 			var e = doDecode();
 			var name = doDecodeString();
-			EFunction(params,e,(name == "") ? null: name);
+			EFunction(Tools.getFunctionType(name), {args:params,expr:e});
 		case 15:
 			EReturn(doDecode());
 		case 16:

--- a/hscript/Checker.hx
+++ b/hscript/Checker.hx
@@ -823,7 +823,7 @@ class Checker {
                         }
                     }
                 }
-                match = match && (ret == null || tryUnify(fRet, ret));
+                match = match && (ret == null || tryUnify(ret, fRet));
                 match;
             default: false;
         });

--- a/hscript/Checker.hx
+++ b/hscript/Checker.hx
@@ -50,8 +50,8 @@ typedef CClass = {> CNamedType,
     @:optional var constructor : CField;
     @:optional var interfaces : Array<TType>;
 	@:optional var isInterface : Bool;
-    var fields : Map<String,CField>;
-    var statics : Map<String,CField>;
+    var fields : Array<CField>;
+    var statics : Array<CField>;
 }
 
 typedef CField = {
@@ -73,6 +73,9 @@ typedef CTypedef = {> CNamedType,
 
 typedef CAbstract = {> CNamedType,
     var t : TType;
+    @:optional var constructor : CField;
+    var fields : Array<CField>;
+    var statics : Array<CField>;
 }
 
 class Completion {

--- a/hscript/Checker.hx
+++ b/hscript/Checker.hx
@@ -888,7 +888,7 @@ class Checker {
         if( isCompletion ) throw new Completion(expr, t);
     }
 
-    function typeField( o : Expr, f : String, expr : Expr, forWrite : Bool ) {
+    function typeField( o : Expr, f : String, expr : Expr, forWrite : Bool, ?args:Array<Expr>) {
         var ot = typeExpr(o, Value);
         if( f == null )
             onCompletion(expr, ot);
@@ -900,7 +900,7 @@ class Checker {
         return ft;
     }
 
-    function typeExpr( expr : Expr, withType : WithType ) : TType {
+    function typeExpr( expr : Expr, withType : WithType, ?args:Array<Expr>) : TType {
         if( expr == null && isCompletion )
             return switch( withType ) {
             case WithType(t): t;
@@ -958,7 +958,7 @@ class Checker {
         case EParent(e):
             return typeExpr(e,withType);
         case ECall(e, params):
-            var ft = typeExpr(e, Value);
+            var ft = typeExpr(e, Value, params);
             switch( follow(ft) ) {
             case TFun(args, ret):
                 for( i in 0...params.length ) {
@@ -983,8 +983,8 @@ class Checker {
             }
         case EField(o, f):
             var typeName = new Printer().exprToString(o);
-            if(globals.exists(typeName)) return typeField(EIdent(typeName).mk(expr),f, expr, false);
-            else return typeField(o,f,expr,false);
+            if(globals.exists(typeName)) return typeField(EIdent(typeName).mk(expr),f, expr, false, args);
+            else return typeField(o,f,expr,false, args);
         case ECheckType(v, t):
             var ct = makeType(t, expr);
             var vt = typeExpr(v, WithType(ct));

--- a/hscript/Checker.hx
+++ b/hscript/Checker.hx
@@ -380,7 +380,7 @@ class Checker {
                     }
                 }
                 switch( edef(e) ) {
-                case EFunction(args,_,name,ret) if( name != null ):
+                case EFunction(Tools.getFunctionName(_) => name, {args:args,ret:ret}) if( ['anon','arrow',null].indexOf(name) == -1):
                     var tret = ret == null ? makeMono() : makeType(ret, e);
                     var ft = TFun(typeArgs(args,e),tret);
                     locals.set(name, ft);
@@ -1082,7 +1082,7 @@ class Checker {
         case EThrow(e):
             typeExpr(e, Value);
             return makeMono();
-        case EFunction(args, body, name, ret):
+        case EFunction(Tools.getFunctionName(_) => name, {args:args, expr:body, ret:ret}):
             var ft = null, tret = null, targs = null;
             if( currentFunType != null ) {
                 switch( currentFunType ) {

--- a/hscript/Checker.hx
+++ b/hscript/Checker.hx
@@ -380,7 +380,7 @@ class Checker {
                     }
                 }
                 switch( edef(e) ) {
-                case EFunction(Tools.getFunctionName(_) => name, {args:args,ret:ret}) if( ['anon','arrow',null].indexOf(name) == -1):
+                case EFunction(FNamed(name, _), {args:args,ret:ret}):
                     var tret = ret == null ? makeMono() : makeType(ret, e);
                     var ft = TFun(typeArgs(args,e),tret);
                     locals.set(name, ft);

--- a/hscript/Checker.hx
+++ b/hscript/Checker.hx
@@ -2,128 +2,134 @@ package hscript;
 import hscript.Expr;
 
 /**
-	This is a special type that can be used in API.
-	It will be type-checked as `Script` but will compile/execute as `Real`
+    This is a special type that can be used in API.
+    It will be type-checked as `Script` but will compile/execute as `Real`
 **/
 typedef TypeCheck<Real,Script> = Real;
 
 enum TType {
-	TMono( r : { r : TType } );
-	TVoid;
-	TInt;
-	TFloat;
-	TBool;
-	TDynamic;
-	TParam( name : String );
-	TUnresolved( name : String );
-	TNull( t : TType );
-	TInst( c : CClass, args : Array<TType> );
-	TEnum( e : CEnum, args : Array<TType> );
-	TType( t : CTypedef, args : Array<TType> );
-	TAbstract( a : CAbstract, args : Array<TType> );
-	TFun( args : Array<{ name : String, opt : Bool, t : TType }>, ret : TType );
-	TAnon( fields : Array<{ name : String, opt : Bool, t : TType }> );
-	TLazy( f : Void -> TType );
+    TMono( r : { r : TType } );
+    TVoid;
+    TInt;
+    TFloat;
+    TBool;
+    TDynamic;
+    TParam( name : String );
+    TUnresolved( name : String );
+    TNull( t : TType );
+    TInst( c : CClass, args : Array<TType> );
+    TEnum( e : CEnum, args : Array<TType> );
+    TType( t : CTypedef, args : Array<TType> );
+    TAbstract( a : CAbstract, args : Array<TType> );
+    TFun( args : Array<{ name : String, opt : Bool, t : TType }>, ret : TType );
+    TAnon( fields : Array<{ name : String, opt : Bool, t : TType }> );
+    TLazy( f : Void -> TType );
 }
 
-private enum WithType {
-	NoValue;
-	Value;
-	WithType( t : TType );
+enum WithType {
+    NoValue;
+    Value;
+    WithType( t : TType );
 }
 
 enum CTypedecl {
-	CTClass( c : CClass );
-	CTEnum( e : CEnum );
-	CTTypedef( t : CTypedef );
-	CTAlias( t : TType );
-	CTAbstract( a : CAbstract );
+    CTClass( c : CClass );
+    CTEnum( e : CEnum );
+    CTTypedef( t : CTypedef );
+    CTAlias( t : TType );
+    CTAbstract( a : CAbstract );
 }
 
 typedef CNamedType = {
-	var name : String;
-	var params : Array<TType>;
+    var name : String;
+    var params : Array<TType>;
 }
 
 typedef CClass = {> CNamedType,
-	@:optional var superClass : TType;
-	@:optional var constructor : CField;
-	@:optional var interfaces : Array<TType>;
+    @:optional var superClass : TType;
+    @:optional var constructor : CField;
+    @:optional var interfaces : Array<TType>;
 	@:optional var isInterface : Bool;
-	var fields : Map<String,CField>;
-	var statics : Map<String,CField>;
+    var fields : Map<String,CField>;
+    var statics : Map<String,CField>;
 }
 
 typedef CField = {
-	var isPublic : Bool;
-	var canWrite : Bool;
-	var complete : Bool;
-	var params : Array<TType>;
-	var name : String;
-	var t : TType;
+    var isPublic : Bool;
+    var canWrite : Bool;
+    var complete : Bool;
+    var params : Array<TType>;
+    var name : String;
+    var t : TType;
 }
 
 typedef CEnum = {> CNamedType,
-	var constructors : Array<{ name : String, ?args : Array<{ name : String, opt : Bool, t : TType }> }>;
+    var constructors : Array<{ name : String, ?args : Array<{ name : String, opt : Bool, t : TType }> }>;
 }
 
 typedef CTypedef = {> CNamedType,
-	var t : TType;
+    var t : TType;
 }
 
 typedef CAbstract = {> CNamedType,
-	var t : TType;
+    var t : TType;
 }
 
 class Completion {
-	public var expr : Expr;
-	public var t : TType;
-	public function new(expr,t) {
-		this.expr = expr;
-		this.t = t;
-	}
+    public var expr : Expr;
+    public var t : TType;
+    public function new(expr,t) {
+        this.expr = expr;
+        this.t = t;
+    }
 }
 
-@:allow(hscript.Checker)
-class CheckerTypes {
+// @:allow(hscript.Checker)
+interface CheckerTypes {
+    function resolve( name : String, ?args : Array<TType> ) : TType;
+    function getType( name : String, ?args : Array<TType> ) : TType;
+    var t_string : TType;
+}
 
-	var types : Map<String,CTypedecl> = new Map();
-	var t_string : TType;
-	var localParams : Map<String,TType>;
+class XmlCheckerTypes implements CheckerTypes {
 
-	public function new() {
-		types = new Map();
-		types.set("Void",CTAlias(TVoid));
-		types.set("Int",CTAlias(TInt));
-		types.set("Float",CTAlias(TFloat));
-		types.set("Bool",CTAlias(TBool));
-		types.set("Dynamic",CTAlias(TDynamic));
-	}
+    var types : Map<String,CTypedecl> = new Map();
+    public var t_string : TType;
+    var localParams : Map<String,TType>;
 
-	public function addXmlApi( api : Xml ) {
-		var types = new haxe.rtti.XmlParser();
-		types.process(api, "");
-		var todo = [];
-		for( v in types.root )
-			addXmlType(v,todo);
-		for( f in todo )
-			f();
-		t_string = getType("String");
-	}
+    public function new() {
+        types = new Map();
+        types.set("Void",CTAlias(TVoid));
+        types.set("Int",CTAlias(TInt));
+        types.set("Float",CTAlias(TFloat));
+        types.set("Bool",CTAlias(TBool));
+        types.set("Dynamic",CTAlias(TDynamic));
+    }
 
-	function addXmlType(x:haxe.rtti.CType.TypeTree,todo:Array<Void->Void>) {
-		switch (x) {
-		case TPackage(name, full, subs):
-			for( s in subs ) addXmlType(s,todo);
-		case TClassdecl(c):
-			if( types.exists(c.path) ) return;
-			var cl : CClass = {
-				name : c.path,
-				params : [],
-				fields : new Map(),
-				statics : new Map(),
-			};
-			if( c.isInterface )
+    public function addXmlApi( api : Xml ) {
+        var types = new haxe.rtti.XmlParser();
+        types.process(api, "");
+        var todo = [];
+        for( v in types.root )
+            addXmlType(v,todo);
+        for( f in todo )
+            f();
+        t_string = getType("String");
+    }
+
+    function addXmlType(x:haxe.rtti.CType.TypeTree,todo:Array<Void->Void>) {
+        switch (x) {
+        case TPackage(name, full, subs):
+            for( s in subs ) addXmlType(s,todo);
+        case TClassdecl(c):
+            if( types.exists(c.path) ) return;
+            var cl : CClass = {
+                name : c.path,
+                params : [],
+                fields : new Map(),
+                statics : new Map(),
+            };
+            if( c.isInterface )
 				cl.isInterface = true;
 			for( p in c.params )
 				cl.params.push(TParam(p));
@@ -137,174 +143,174 @@ class CheckerTypes {
 						cl.interfaces.push(getType(i.path, [for( t in i.params ) makeXmlType(t)]));
 				}
 				var pkeys = [];
-				for( f in c.fields ) {
-					if( f.isOverride || f.name.substr(0,4) == "get_" || f.name.substr(0,4) == "set_" ) continue;
-					var skip = false;
-					var complete = !StringTools.startsWith(f.name,"__"); // __uid, etc. (no metadata in such fields)
-					for( m in f.meta ) {
-						if( m.name == ":noScript"  ) {
-							skip = true;
-							break;
-						}
-						if( m.name == ":noCompletion" )
-							complete = false;
-					}
-					if( skip ) continue;
-					var fl : CField = { isPublic : f.isPublic, canWrite : f.set.match(RNormal | RCall(_) | RDynamic), complete : complete, params : [], name : f.name, t : null };
-					for( p in f.params ) {
-						var pt = TParam(p);
-						var key = f.name+"."+p;
-						pkeys.push(key);
-						fl.params.push(pt);
-						localParams.set(key, pt);
-					}
-					fl.t = makeXmlType(f.type);
-					while( pkeys.length > 0 )
-						localParams.remove(pkeys.pop());
-					if( fl.name == "new" )
-						cl.constructor = fl;
-					else
-						cl.fields.set(f.name, fl);
-				}
-				localParams = null;
-			});
-			types.set(cl.name, CTClass(cl));
-		case TEnumdecl(e):
-			if( types.exists(e.path) ) return;
-			var en : CEnum = {
-				name : e.path,
-				params : [],
-				constructors: [],
-			};
-			for( p in e.params )
-				en.params.push(TParam(p));
-			todo.push(function() {
-				localParams = [for( t in en.params ) e.path+"."+Checker.typeStr(t) => t];
-				for( c in e.constructors )
-					en.constructors.push({ name : c.name, args : c.args == null ? null : [for( a in c.args ) { name : a.name, opt : a.opt, t : makeXmlType(a.t) }] });
-				localParams = null;
-			});
-			types.set(en.name, CTEnum(en));
-		case TTypedecl(t):
-			if( types.exists(t.path) ) return;
-			var td : CTypedef = {
-				name : t.path,
-				params : [],
-				t : null,
-			};
-			for( p in t.params )
-				td.params.push(TParam(p));
-			if( t.path == "hscript.TypeCheck" )
-				td.params.reverse();
-			todo.push(function() {
-				localParams = [for( pt in td.params ) t.path+"."+Checker.typeStr(pt) => pt];
-				td.t = makeXmlType(t.type);
-				localParams = null;
-			});
-			types.set(t.path, CTTypedef(td));
-		case TAbstractdecl(a):
-			if( types.exists(a.path) ) return;
-			var ta : CAbstract = {
-				name : a.path,
-				params : [],
-				t : null,
-			};
-			for( p in a.params )
-				ta.params.push(TParam(p));
-			todo.push(function() {
-				localParams = [for( t in ta.params ) a.path+"."+Checker.typeStr(t) => t];
-				ta.t = makeXmlType(a.athis);
-				localParams = null;
-			});
-			types.set(a.path, CTAbstract(ta));
-		}
-	}
+                for( f in c.fields ) {
+                    if( f.isOverride || f.name.substr(0,4) == "get_" || f.name.substr(0,4) == "set_" ) continue;
+                    var skip = false;
+                    var complete = !StringTools.startsWith(f.name,"__"); // __uid, etc. (no metadata in such fields)
+                    for( m in f.meta ) {
+                        if( m.name == ":noScript"  ) {
+                            skip = true;
+                            break;
+                        }
+                        if( m.name == ":noCompletion" )
+                            complete = false;
+                    }
+                    if( skip ) continue;
+                    var fl : CField = { isPublic : f.isPublic, canWrite : f.set.match(RNormal | RCall(_) | RDynamic), complete : complete, params : [], name : f.name, t : null };
+                    for( p in f.params ) {
+                        var pt = TParam(p);
+                        var key = f.name+"."+p;
+                        pkeys.push(key);
+                        fl.params.push(pt);
+                        localParams.set(key, pt);
+                    }
+                    fl.t = makeXmlType(f.type);
+                    while( pkeys.length > 0 )
+                        localParams.remove(pkeys.pop());
+                    if( fl.name == "new" )
+                        cl.constructor = fl;
+                    else
+                        cl.fields.set(f.name, fl);
+                }
+                localParams = null;
+            });
+            types.set(cl.name, CTClass(cl));
+        case TEnumdecl(e):
+            if( types.exists(e.path) ) return;
+            var en : CEnum = {
+                name : e.path,
+                params : [],
+                constructors: [],
+            };
+            for( p in e.params )
+                en.params.push(TParam(p));
+            todo.push(function() {
+                localParams = [for( t in en.params ) e.path+"."+Checker.typeStr(t) => t];
+                for( c in e.constructors )
+                    en.constructors.push({ name : c.name, args : c.args == null ? null : [for( a in c.args ) { name : a.name, opt : a.opt, t : makeXmlType(a.t) }] });
+                localParams = null;
+            });
+            types.set(en.name, CTEnum(en));
+        case TTypedecl(t):
+            if( types.exists(t.path) ) return;
+            var td : CTypedef = {
+                name : t.path,
+                params : [],
+                t : null,
+            };
+            for( p in t.params )
+                td.params.push(TParam(p));
+            if( t.path == "hscript.TypeCheck" )
+                td.params.reverse();
+            todo.push(function() {
+                localParams = [for( pt in td.params ) t.path+"."+Checker.typeStr(pt) => pt];
+                td.t = makeXmlType(t.type);
+                localParams = null;
+            });
+            types.set(t.path, CTTypedef(td));
+        case TAbstractdecl(a):
+            if( types.exists(a.path) ) return;
+            var ta : CAbstract = {
+                name : a.path,
+                params : [],
+                t : null,
+            };
+            for( p in a.params )
+                ta.params.push(TParam(p));
+            todo.push(function() {
+                localParams = [for( t in ta.params ) a.path+"."+Checker.typeStr(t) => t];
+                ta.t = makeXmlType(a.athis);
+                localParams = null;
+            });
+            types.set(a.path, CTAbstract(ta));
+        }
+    }
 
-	function makeXmlType( t : haxe.rtti.CType.CType ) : TType {
-		return switch (t) {
-		case CUnknown: TUnresolved("Unknown");
-		case CEnum(name, params): getType(name,[for( t in params ) makeXmlType(t)]);
-		case CClass(name, params): getType(name,[for( t in params ) makeXmlType(t)]);
-		case CTypedef(name, params): getType(name,[for( t in params ) makeXmlType(t)]);
-		case CFunction(args, ret): TFun([for( a in args ) { name : a.name, opt : a.opt, t : makeXmlType(a.t) }], makeXmlType(ret));
-		case CAnonymous(fields):
-			inline function isOpt(m:haxe.rtti.CType.MetaData) {
-				if( m == null ) return false;
-				var b = false;
-				for( m in m ) if( m.name == ":optional" ) { b = true; break; }
-				return b;
-			}
-			TAnon([for( f in fields ) { name : f.name, t : makeXmlType(f.type), opt : isOpt(f.meta) }]);
-		case CDynamic(t): TDynamic;
-		case CAbstract(name, params):
-			switch( name ) {
-			default:
-				getType(name,[for( t in params ) makeXmlType(t)]);
-			}
-		}
-	}
+    function makeXmlType( t : haxe.rtti.CType.CType ) : TType {
+        return switch (t) {
+        case CUnknown: TUnresolved("Unknown");
+        case CEnum(name, params): getType(name,[for( t in params ) makeXmlType(t)]);
+        case CClass(name, params): getType(name,[for( t in params ) makeXmlType(t)]);
+        case CTypedef(name, params): getType(name,[for( t in params ) makeXmlType(t)]);
+        case CFunction(args, ret): TFun([for( a in args ) { name : a.name, opt : a.opt, t : makeXmlType(a.t) }], makeXmlType(ret));
+        case CAnonymous(fields):
+            inline function isOpt(m:haxe.rtti.CType.MetaData) {
+                if( m == null ) return false;
+                var b = false;
+                for( m in m ) if( m.name == ":optional" ) { b = true; break; }
+                return b;
+            }
+            TAnon([for( f in fields ) { name : f.name, t : makeXmlType(f.type), opt : isOpt(f.meta) }]);
+        case CDynamic(t): TDynamic;
+        case CAbstract(name, params):
+            switch( name ) {
+            default:
+                getType(name,[for( t in params ) makeXmlType(t)]);
+            }
+        }
+    }
 
-	function getType( name : String, ?args : Array<TType> ) : TType {
-		if( localParams != null ) {
-			var t = localParams.get(name);
-			if( t != null ) return t;
-		}
-		var t = resolve(name,args);
-		if( t == null ) {
-			var pack = name.split(".");
-			if( pack.length > 1 ) {
-				// bugfix for some args reported as pack._Name.Name while they are not private
-				var priv = pack[pack.length-2];
-				if( priv.charCodeAt(0) == "_".code ) {
-					pack.remove(priv);
-					return getType(pack.join("."), args);
-				}
-			}
-			return TUnresolved(name); // most likely private class
-		}
-		return t;
-	}
+    public function getType( name : String, ?args : Array<TType> ) : TType {
+        if( localParams != null ) {
+            var t = localParams.get(name);
+            if( t != null ) return t;
+        }
+        var t = resolve(name,args);
+        if( t == null ) {
+            var pack = name.split(".");
+            if( pack.length > 1 ) {
+                // bugfix for some args reported as pack._Name.Name while they are not private
+                var priv = pack[pack.length-2];
+                if( priv.charCodeAt(0) == "_".code ) {
+                    pack.remove(priv);
+                    return getType(pack.join("."), args);
+                }
+            }
+            return TUnresolved(name); // most likely private class
+        }
+        return t;
+    }
 
-	public function resolve( name : String, ?args : Array<TType> ) : TType {
-		if( name == "Null" ) {
-			if( args == null || args.length != 1 ) throw "Missing Null<T> parameter";
-			return TNull(args[0]);
-		}
-		var t = types.get(name);
-		if( t == null ) return null;
-		if( args == null ) args = [];
-		return switch( t ) {
-		case CTClass(c): TInst(c,args);
-		case CTEnum(e): TEnum(e,args);
-		case CTTypedef(t): TType(t,args);
-		case CTAbstract(a): TAbstract(a, args);
-		case CTAlias(t): t;
-		}
-	}
+    public function resolve( name : String, ?args : Array<TType> ) : TType {
+        if( name == "Null" ) {
+            if( args == null || args.length != 1 ) throw "Missing Null<T> parameter";
+            return TNull(args[0]);
+        }
+        var t = types.get(name);
+        if( t == null ) return null;
+        if( args == null ) args = [];
+        return switch( t ) {
+        case CTClass(c): TInst(c,args);
+        case CTEnum(e): TEnum(e,args);
+        case CTTypedef(t): TType(t,args);
+        case CTAbstract(a): TAbstract(a, args);
+        case CTAlias(t): t;
+        }
+    }
 
 }
 
 class Checker {
 
-	public var types : CheckerTypes;
-	var locals : Map<String,TType>;
-	var globals : Map<String,TType> = new Map();
-	var events : Map<String,TType> = new Map();
-	var currentFunType : TType;
-	var isCompletion : Bool;
-	var allowDefine : Bool;
-	public var allowAsync : Bool;
-	public var allowReturn : Null<TType>;
-	public var allowGlobalsDefine : Bool;
-	public var allowUntypedMeta : Bool;
+    public var types : CheckerTypes;
+    var locals : Map<String,TType>;
+    var globals : Map<String,TType> = new Map();
+    var events : Map<String,TType> = new Map();
+    var currentFunType : TType;
+    var isCompletion : Bool;
+    var allowDefine : Bool;
+    public var allowAsync : Bool;
+    public var allowReturn : Null<TType>;
+    public var allowGlobalsDefine : Bool;
+    public var allowUntypedMeta : Bool;
 
-	public function new( ?types ) {
-		if( types == null ) types = new CheckerTypes();
-		this.types = types;
-	}
+    public function new( ?types:CheckerTypes ) {
+        if( types == null ) types = new XmlCheckerTypes();
+        this.types = types;
+    }
 
-	public function setGlobals( cl : CClass ) {
-		while( true ) {
+    public function setGlobals( cl : CClass ) {
+        while( true ) {
 			for( f in cl.fields )
 				if( f.isPublic )
 					setGlobal(f.name, f.params.length == 0 ? f.t : TLazy(function() return apply(f.t,f.params,[for( i in 0...f.params.length) makeMono()])));
@@ -315,306 +321,306 @@ class Checker {
 			default: throw "assert";
 			}
 		}
-	}
+    }
 
-	public function removeGlobal( name : String ) {
-		globals.remove(name);
-	}
+    public function removeGlobal( name : String ) {
+        globals.remove(name);
+    }
 
-	public function setGlobal( name : String, type : TType ) {
-		globals.set(name, type);
-	}
+    public function setGlobal( name : String, type : TType ) {
+        globals.set(name, type);
+    }
 
-	public function setEvent( name : String, type : TType ) {
-		events.set(name, type);
-	}
+    public function setEvent( name : String, type : TType ) {
+        events.set(name, type);
+    }
 
-	public function getGlobals() {
-		return globals;
-	}
+    public function getGlobals() {
+        return globals;
+    }
 
-	function typeArgs( args : Array<Argument>, pos : Expr ) {
-		return [for( i in 0...args.length ) {
-			var a = args[i];
-			var at = a.t == null ? makeMono() : makeType(a.t, pos);
-			{ name : a.name, opt : a.opt, t : at };
-		}];
-	}
+    function typeArgs( args : Array<Argument>, pos : Expr ) {
+        return [for( i in 0...args.length ) {
+            var a = args[i];
+            var at = a.t == null ? makeMono() : makeType(a.t, pos);
+            { name : a.name, opt : a.opt, t : at };
+        }];
+    }
 
-	public function check( expr : Expr, ?withType : WithType, ?isCompletion = false ) {
-		if( withType == null ) withType = NoValue;
-		locals = new Map();
-		allowDefine = allowGlobalsDefine;
-		this.isCompletion = isCompletion;
-		switch( edef(expr) ) {
-		case EBlock(el):
-			var delayed = [];
-			var last = TVoid;
-			for( e in el ) {
-				while( true ) {
-					switch( edef(e) ) {
-					case EMeta(_,_,e2): e = e2;
-					default: break;
-					}
-				}
-				switch( edef(e) ) {
-				case EFunction(args,_,name,ret) if( name != null ):
-					var tret = ret == null ? makeMono() : makeType(ret, e);
-					var ft = TFun(typeArgs(args,e),tret);
-					locals.set(name, ft);
-					delayed.push(function() {
-						currentFunType = ft;
-						typeExpr(e, NoValue);
-						return ft;
-					});
-				default:
-					for( f in delayed ) f();
-					delayed = [];
-					if( el[el.length-1] == e )
-						last = typeExpr(e, withType);
-					else
-						typeExpr(e, NoValue);
-				}
-			}
-			for( f in delayed )
-				last = f();
-			return last;
-		default:
-		}
-		return typeExpr(expr,withType);
-	}
+    public function check( expr : Expr, ?withType : WithType, ?isCompletion = false ) {
+        if( withType == null ) withType = NoValue;
+        locals = new Map();
+        allowDefine = allowGlobalsDefine;
+        this.isCompletion = isCompletion;
+        switch( edef(expr) ) {
+        case EBlock(el):
+            var delayed = [];
+            var last = TVoid;
+            for( e in el ) {
+                while( true ) {
+                    switch( edef(e) ) {
+                    case EMeta(_,_,e2): e = e2;
+                    default: break;
+                    }
+                }
+                switch( edef(e) ) {
+                case EFunction(args,_,name,ret) if( name != null ):
+                    var tret = ret == null ? makeMono() : makeType(ret, e);
+                    var ft = TFun(typeArgs(args,e),tret);
+                    locals.set(name, ft);
+                    delayed.push(function() {
+                        currentFunType = ft;
+                        typeExpr(e, NoValue);
+                        return ft;
+                    });
+                default:
+                    for( f in delayed ) f();
+                    delayed = [];
+                    if( el[el.length-1] == e )
+                        last = typeExpr(e, withType);
+                    else
+                        typeExpr(e, NoValue);
+                }
+            }
+            for( f in delayed )
+                last = f();
+            return last;
+        default:
+        }
+        return typeExpr(expr,withType);
+    }
 
-	inline function edef( e : Expr ) {
-		#if hscriptPos
-		return e.e;
-		#else
-		return e;
-		#end
-	}
+    inline function edef( e : Expr ) {
+        #if hscriptPos
+        return e.e;
+        #else
+        return e;
+        #end
+    }
 
-	inline function error( msg : String, curExpr : Expr ) {
-		var e = ECustom(msg);
-		#if hscriptPos var e = new Error(e, curExpr.pmin, curExpr.pmax, curExpr.origin, curExpr.line); #end
-		if( !isCompletion ) throw e;
-	}
+    inline function error( msg : String, curExpr : Expr ) {
+        var e = ECustom(msg);
+        #if hscriptPos var e = new Error(e, curExpr.pmin, curExpr.pmax, curExpr.origin, curExpr.line); #end
+        if( !isCompletion ) throw e;
+    }
 
-	function saveLocals() {
-		return [for( k in locals.keys() ) k => locals.get(k)];
-	}
+    function saveLocals() {
+        return [for( k in locals.keys() ) k => locals.get(k)];
+    }
 
-	function makeType( t : CType, e : Expr ) : TType {
-		return switch (t) {
-		case CTPath(path, params):
-			var ct = types.resolve(path.join("."),params == null ? [] : [for( p in params ) makeType(p,e)]);
-			if( ct == null ) {
-				error("Unknown type "+path, e);
-				ct = TDynamic;
-			}
-			return ct;
-		case CTFun(args, ret):
-			var i = 0;
-			return TFun([for( a in args ) { name : "p"+(i++), opt : false, t : makeType(a,e) }], makeType(ret,e));
-		case CTAnon(fields):
-			return TAnon([for( f in fields ) { name : f.name, opt : false, t : makeType(f.t,e) }]);
-		case CTParent(t):
-			return makeType(t,e);
-		case CTNamed(n, t):
-			return makeType(t,e);
-		case CTOpt(t):
-			return makeType(t,e);
-		}
-	}
+    public function makeType( t : CType, ?e : Expr,?pos:haxe.PosInfos) : TType {
+        return if(t == null) TVoid else switch (t) {
+        case CTPath(path, params):
+            var ct = types.resolve(path.join("."),params == null ? [] : [for( p in params ) makeType(p,e)]);
+            if( ct == null ) {
+                error("Unknown type "+path, if(e != null) e else Tools.mk(EIdent('null'), e));
+                ct = TDynamic;
+            }
+            return ct;
+        case CTFun(args, ret):
+            var i = 0;
+            return TFun([for( a in args ) { name : "p"+(i++), opt : false, t : makeType(a,e) }], makeType(ret,e));
+        case CTAnon(fields):
+            return TAnon([for( f in fields ) { name : f.name, opt : false, t : makeType(f.t,e) }]);
+        case CTParent(t):
+            return makeType(t,e);
+        case CTNamed(n, t):
+            return makeType(t,e);
+        case CTOpt(t):
+            return makeType(t,e);
+        }
+    }
 
-	public static function typeStr( t : TType ) {
-		inline function makeArgs(args:Array<TType>) return args.length==0 ? "" : "<"+[for( t in args ) typeStr(t)].join(",")+">";
-		return switch (t) {
-		case TMono(r): r.r == null ? "Unknown" : typeStr(r.r);
-		case TInst(c, args): c.name + makeArgs(args);
-		case TEnum(e, args): e.name + makeArgs(args);
-		case TType(t, args):
-			if( t.name == "hscript.TypeCheck" )
-				typeStr(args[1]);
-			else
-				t.name + makeArgs(args);
-		case TAbstract(a, args): a.name + makeArgs(args);
-		case TFun(args, ret): "(" + [for( a in args ) (a.opt?"?":"")+(a.name == "" ? "" : a.name+":")+typeStr(a.t)].join(", ")+") -> "+typeStr(ret);
-		case TAnon(fields): "{" + [for( f in fields ) (f.opt?"?":"")+f.name+":"+typeStr(f.t)].join(", ")+"}";
-		case TParam(name): name;
-		case TNull(t): "Null<"+typeStr(t)+">";
-		case TUnresolved(name): "?"+name;
-		default: t.getName().substr(1);
-		}
-	}
+    public static function typeStr( t : TType ) {
+        inline function makeArgs(args:Array<TType>) return args.length==0 ? "" : "<"+[for( t in args ) typeStr(t)].join(",")+">";
+        return switch (t) {
+        case TMono(r): r.r == null ? "Unknown" : typeStr(r.r);
+        case TInst(c, args): c.name + makeArgs(args);
+        case TEnum(e, args): e.name + makeArgs(args);
+        case TType(t, args):
+            if( t.name == "hscript.TypeCheck" )
+                typeStr(args[1]);
+            else
+                t.name + makeArgs(args);
+        case TAbstract(a, args): a.name + makeArgs(args);
+        case TFun(args, ret): "(" + [for( a in args ) (a.opt?"?":"")+(a.name == "" ? "" : a.name+":")+typeStr(a.t)].join(", ")+") -> "+typeStr(ret);
+        case TAnon(fields): "{" + [for( f in fields ) (f.opt?"?":"")+f.name+":"+typeStr(f.t)].join(", ")+"}";
+        case TParam(name): name;
+        case TNull(t): "Null<"+typeStr(t)+">";
+        case TUnresolved(name): "?"+name;
+        default: t.getName().substr(1);
+        }
+    }
 
-	function linkLoop( a : TType, t : TType ) {
-		if( t == a ) return true;
-		switch( t ) {
-		case TMono(r):
-			if( r.r == null ) return false;
-			return linkLoop(a,r.r);
-		case TEnum(_,tl), TInst(_,tl), TType(_,tl), TAbstract(_,tl):
-			for( t in tl )
-				if( linkLoop(a,t) )
-					return true;
-			return false;
-		case TFun(args,ret):
-			for( arg in args )
-				if( linkLoop(a,arg.t) )
-					return true;
-			return linkLoop(a,ret);
-		case TDynamic:
-			if( t == TDynamic )
-				return false;
-			return linkLoop(a,TDynamic);
-		case TAnon(fl):
-			for( f in fl )
-				if( linkLoop(a, f.t) )
-					return true;
-			return false;
-		default:
-			return false;
-		}
-	}
+    function linkLoop( a : TType, t : TType ) {
+        if( t == a ) return true;
+        switch( t ) {
+        case TMono(r):
+            if( r.r == null ) return false;
+            return linkLoop(a,r.r);
+        case TEnum(_,tl), TInst(_,tl), TType(_,tl), TAbstract(_,tl):
+            for( t in tl )
+                if( linkLoop(a,t) )
+                    return true;
+            return false;
+        case TFun(args,ret):
+            for( arg in args )
+                if( linkLoop(a,arg.t) )
+                    return true;
+            return linkLoop(a,ret);
+        case TDynamic:
+            if( t == TDynamic )
+                return false;
+            return linkLoop(a,TDynamic);
+        case TAnon(fl):
+            for( f in fl )
+                if( linkLoop(a, f.t) )
+                    return true;
+            return false;
+        default:
+            return false;
+        }
+    }
 
-	function link( a : TType, b : TType, r : { r : TType } ) {
-		if( linkLoop(a,b) )
-			return follow(b) == a;
-		if( b == TDynamic )
-			return true;
-		r.r = b;
-		return true;
-	}
+    function link( a : TType, b : TType, r : { r : TType } ) {
+        if( linkLoop(a,b) )
+            return follow(b) == a;
+        if( b == TDynamic )
+            return true;
+        r.r = b;
+        return true;
+    }
 
-	function typeEq( t1 : TType, t2 : TType ) {
-		if( t1 == t2 )
-			return true;
-		switch( [t1,t2] ) {
-		case [TMono(r), _]:
-			if( r.r == null ) {
-				if( !link(t1,t2,r) )
-					return false;
-				r.r = t2;
+    function typeEq( t1 : TType, t2 : TType ) {
+        if( t1 == t2 )
+            return true;
+        switch( [t1,t2] ) {
+        case [TMono(r), _]:
+            if( r.r == null ) {
+                if( !link(t1,t2,r) )
+                    return false;
+                r.r = t2;
+                return true;
+            }
+            return typeEq(r.r, t2);
+        case [_, TMono(r)]:
+            if( r.r == null ) {
+                if( !link(t2,t1,r) )
+                    return false;
+                r.r = t1;
+                return true;
+            }
+            return typeEq(t1, r.r);
+        case [TType(t1,pl1),TType(t2,pl2)] if( t1 == t2 ):
+            for( i in 0...pl1.length )
+                if( !typeEq(pl1[i],pl2[i]) )
+                    return false;
+            return true;
+        case [TType(t1,pl1), _]:
+            return typeEq(apply(t1.t, t1.params, pl1), t2);
+        case [_,TType(t2,pl2)]:
+            return typeEq(t1, apply(t2.t, t2.params, pl2));
+        case [TInst(cl1,pl1), TInst(cl2,pl2)] if( cl1 == cl2 ):
+            for( i in 0...pl1.length )
+                if( !typeEq(pl1[i],pl2[i]) )
+                    return false;
+            return true;
+        case [TEnum(e1,pl1), TEnum(e2,pl2)] if( e1 == e2 ):
+            for( i in 0...pl1.length )
+                if( !typeEq(pl1[i],pl2[i]) )
+                    return false;
+            return true;
+        case [TAbstract(a1,pl1), TAbstract(a2,pl2)] if( a1 == a2 ):
+            for( i in 0...pl1.length )
+                if( !typeEq(pl1[i],pl2[i]) )
+                    return false;
+            return true;
+        case [TNull(t1), TNull(t2)]:
+            return typeEq(t1,t2);
+        case [TNull(t1), _]:
+            return typeEq(t1,t2);
+        case [_, TNull(t2)]:
+            return typeEq(t1,t2);
+        case [TFun(args1,r1), TFun(args2,r2)] if( args1.length == args2.length ):
+            for( i in 0...args1.length )
+                if( !typeEq(args1[i].t, args2[i].t) )
+                    return false;
+            return typeEq(r1, r2);
+        case [TAnon(a1),TAnon(a2)] if( a1.length == a2.length ):
+            var m = new Map();
+            for( f in a2 )
+                m.set(f.name, f);
+            for( f1 in a1 ) {
+                var f2 = m.get(f1.name);
+                if( f2 == null ) return false;
+                if( !typeEq(f1.t,f2.t) )
+                    return false;
+            }
+            return true;
+        default:
+        }
+        return false;
+    }
+
+    function tryUnify( t1 : TType, t2 : TType ) {
+        if( t1 == t2 )
+            return true;
+        switch( [t1,t2] ) {
+        case [TMono(r), _]:
+            if( r.r == null ) {
+                if( !link(t1,t2,r) )
+                    return false;
+                r.r = t2;
+                return true;
+            }
+            return tryUnify(r.r, t2);
+        case [_, TMono(r)]:
+            if( r.r == null ) {
+                if( !link(t2,t1,r) )
+                    return false;
+                r.r = t1;
+                return true;
+            }
+            return tryUnify(t1, r.r);
+        case [TType(t1,pl1), _]:
+            return tryUnify(apply(t1.t, t1.params, pl1), t2);
+        case [_,TType(t2,pl2)]:
+            return tryUnify(t1, apply(t2.t, t2.params, pl2));
+        case [TNull(t1), _]:
+            return tryUnify(t1,t2);
+        case [_, TNull(t2)]:
+            return tryUnify(t1,t2);
+        case [TFun(args1,r1),TFun(args2,r2)] if( args1.length == args2.length ):
+            for( i in 0...args1.length ) {
+                var a1 = args1[i];
+                var a2 = args2[i];
+                if( a2.opt && !a1.opt ) return false;
+                if( !tryUnify(a2.t, a1.t) ) return false;
+            }
+            return tryUnify(r1,r2);
+        case [_, TDynamic]:
+            return true;
+        case [TDynamic, _]:
+            return true;
+        case [TAnon(a1),TAnon(a2)]:
+            if( a2.length == 0 ) // always unify with {}
 				return true;
-			}
-			return typeEq(r.r, t2);
-		case [_, TMono(r)]:
-			if( r.r == null ) {
-				if( !link(t2,t1,r) )
-					return false;
-				r.r = t1;
-				return true;
-			}
-			return typeEq(t1, r.r);
-		case [TType(t1,pl1),TType(t2,pl2)] if( t1 == t2 ):
-			for( i in 0...pl1.length )
-				if( !typeEq(pl1[i],pl2[i]) )
-					return false;
-			return true;
-		case [TType(t1,pl1), _]:
-			return typeEq(apply(t1.t, t1.params, pl1), t2);
-		case [_,TType(t2,pl2)]:
-			return typeEq(t1, apply(t2.t, t2.params, pl2));
-		case [TInst(cl1,pl1), TInst(cl2,pl2)] if( cl1 == cl2 ):
-			for( i in 0...pl1.length )
-				if( !typeEq(pl1[i],pl2[i]) )
-					return false;
-			return true;
-		case [TEnum(e1,pl1), TEnum(e2,pl2)] if( e1 == e2 ):
-			for( i in 0...pl1.length )
-				if( !typeEq(pl1[i],pl2[i]) )
-					return false;
-			return true;
-		case [TAbstract(a1,pl1), TAbstract(a2,pl2)] if( a1 == a2 ):
-			for( i in 0...pl1.length )
-				if( !typeEq(pl1[i],pl2[i]) )
-					return false;
-			return true;
-		case [TNull(t1), TNull(t2)]:
-			return typeEq(t1,t2);
-		case [TNull(t1), _]:
-			return typeEq(t1,t2);
-		case [_, TNull(t2)]:
-			return typeEq(t1,t2);
-		case [TFun(args1,r1), TFun(args2,r2)] if( args1.length == args2.length ):
-			for( i in 0...args1.length )
-				if( !typeEq(args1[i].t, args2[i].t) )
-					return false;
-			return typeEq(r1, r2);
-		case [TAnon(a1),TAnon(a2)] if( a1.length == a2.length ):
-			var m = new Map();
-			for( f in a2 )
-				m.set(f.name, f);
-			for( f1 in a1 ) {
-				var f2 = m.get(f1.name);
-				if( f2 == null ) return false;
-				if( !typeEq(f1.t,f2.t) )
-					return false;
-			}
-			return true;
-		default:
-		}
-		return false;
-	}
-
-	function tryUnify( t1 : TType, t2 : TType ) {
-		if( t1 == t2 )
-			return true;
-		switch( [t1,t2] ) {
-		case [TMono(r), _]:
-			if( r.r == null ) {
-				if( !link(t1,t2,r) )
-					return false;
-				r.r = t2;
-				return true;
-			}
-			return tryUnify(r.r, t2);
-		case [_, TMono(r)]:
-			if( r.r == null ) {
-				if( !link(t2,t1,r) )
-					return false;
-				r.r = t1;
-				return true;
-			}
-			return tryUnify(t1, r.r);
-		case [TType(t1,pl1), _]:
-			return tryUnify(apply(t1.t, t1.params, pl1), t2);
-		case [_,TType(t2,pl2)]:
-			return tryUnify(t1, apply(t2.t, t2.params, pl2));
-		case [TNull(t1), _]:
-			return tryUnify(t1,t2);
-		case [_, TNull(t2)]:
-			return tryUnify(t1,t2);
-		case [TFun(args1,r1),TFun(args2,r2)] if( args1.length == args2.length ):
-			for( i in 0...args1.length ) {
-				var a1 = args1[i];
-				var a2 = args2[i];
-				if( a2.opt && !a1.opt ) return false;
-				if( !tryUnify(a2.t, a1.t) ) return false;
-			}
-			return tryUnify(r1,r2);
-		case [_, TDynamic]:
-			return true;
-		case [TDynamic, _]:
-			return true;
-		case [TAnon(a1),TAnon(a2)]:
-			if( a2.length == 0 ) // always unify with {}
-				return true;
-			var m = new Map();
-			for( f in a1 )
-				m.set(f.name, f);
-			for( f2 in a2 ) {
-				var f1 = m.get(f2.name);
-				if( f1 == null ) {
-					if( f2.opt ) continue;
-					return false;
-				}
-				if( !typeEq(f1.t,f2.t) )
-					return false;
-			}
-			return true;
-		case [TInst(cl1,pl1), TInst(cl2,pl2)]:
-			while( cl1 != cl2 ) {
-				if( cl1.interfaces != null ) {
+            var m = new Map();
+            for( f in a1 )
+                m.set(f.name, f);
+            for( f2 in a2 ) {
+                var f1 = m.get(f2.name);
+                if( f1 == null ) {
+                    if( f2.opt ) continue;
+                    return false;
+                }
+                if( !typeEq(f1.t,f2.t) )
+                    return false;
+            }
+            return true;
+        case [TInst(cl1,pl1), TInst(cl2,pl2)]:
+            while( cl1 != cl2 ) {
+                if( cl1.interfaces != null ) {
 					for( i in cl1.interfaces ) {
 						switch( i ) {
 						case TInst(cli, args):
@@ -626,95 +632,95 @@ class Checker {
 						}
 					}
 				}
-				switch( cl1.superClass ) {
-				case null: return false;
-				case TInst(c, args):
-					pl1 = [for( a in args ) apply(a,cl1.params,pl1)];
-					cl1 = c;
-				default: throw "assert";
-				}
-			}
-			for( i in 0...pl1.length )
-				if( !typeEq(pl1[i],pl2[i]) )
-					return false;
-			return true;
-		case [TInst(cl1,pl1),TAnon(fl)]:
-			for( i in 0...fl.length ) {
-				var f2 = fl[i];
-				var f1 = null;
-				var cl = cl1;
-				while( true ) {
-				 	f1 = cl.fields.get(f2.name);
-					if( f1 != null ) break;
-					if( cl.superClass == null )
-						return false;
-					cl = switch( cl.superClass ) {
-					case TInst(c,_): c;
-					default: throw "assert";
-					}
-				}
-				if( !typeEq(f1.t,f2.t) )
-					return false;
-			}
-			return true;
-		case [TInt, TFloat]:
-			return true;
-		case [TFun(_), TAbstract({ name : "haxe.Function" },_)]:
-			return true;
-		default:
-		}
-		return typeEq(t1,t2);
-	}
+                switch( cl1.superClass ) {
+                case null: return false;
+                case TInst(c, args):
+                    pl1 = [for( a in args ) apply(a,cl1.params,pl1)];
+                    cl1 = c;
+                default: throw "assert";
+                }
+            }
+            for( i in 0...pl1.length )
+                if( !typeEq(pl1[i],pl2[i]) )
+                    return false;
+            return true;
+        case [TInst(cl1,pl1),TAnon(fl)]:
+            for( i in 0...fl.length ) {
+                var f2 = fl[i];
+                var f1 = null;
+                var cl = cl1;
+                while( true ) {
+                     f1 = cl.fields.get(f2.name);
+                    if( f1 != null ) break;
+                    if( cl.superClass == null )
+                        return false;
+                    cl = switch( cl.superClass ) {
+                    case TInst(c,_): c;
+                    default: throw "assert";
+                    }
+                }
+                if( !typeEq(f1.t,f2.t) )
+                    return false;
+            }
+            return true;
+        case [TInt, TFloat]:
+            return true;
+        case [TFun(_), TAbstract({ name : "haxe.Function" },_)]:
+            return true;
+        default:
+        }
+        return typeEq(t1,t2);
+    }
 
-	public function unify( t1 : TType, t2 : TType, e : Expr ) {
-		if( !tryUnify(t1,t2) )
-			error(typeStr(t1)+" should be "+typeStr(t2),e);
-	}
+    public function unify( t1 : TType, t2 : TType, e : Expr ) {
+        if( !tryUnify(t1,t2) )
+            error(typeStr(t1)+" should be "+typeStr(t2),e);
+    }
 
-	public function apply( t : TType, params : Array<TType>, args : Array<TType> ) {
-		if( args.length != params.length ) throw "Invalid number of type parameters";
-		if( args.length == 0 )
-			return t;
-		var subst = new Map();
-		for( i in 0...params.length )
-			subst.set(params[i], args[i]);
-		function map(t:TType) {
-			var st = subst.get(t);
-			if( st != null ) return st;
-			return mapType(t,map);
-		}
-		return map(t);
-	}
+    public function apply( t : TType, params : Array<TType>, args : Array<TType> ) {
+        if( args.length != params.length ) throw "Invalid number of type parameters";
+        if( args.length == 0 )
+            return t;
+        var subst = new Map();
+        for( i in 0...params.length )
+            subst.set(params[i], args[i]);
+        function map(t:TType) {
+            var st = subst.get(t);
+            if( st != null ) return st;
+            return mapType(t,map);
+        }
+        return map(t);
+    }
 
-	public function mapType( t : TType, f : TType -> TType ) {
-		switch (t) {
-		case TMono(r):
-			if( r.r == null ) return t;
-			return f(t);
-		case TVoid, TInt, TFloat,TBool,TDynamic,TParam(_), TUnresolved(_):
-			return t;
-		case TEnum(_,[]), TInst(_,[]), TAbstract(_,[]), TType(_,[]):
-			return t;
-		case TNull(t):
-			return TNull(f(t));
-		case TInst(c, args):
-			return TInst(c, [for( t in args ) f(t)]);
-		case TEnum(e, args):
-			return TEnum(e, [for( t in args ) f(t)]);
-		case TType(t, args):
-			return TType(t, [for( t in args ) f(t)]);
-		case TAbstract(a, args):
-			return TAbstract(a, [for( t in args ) f(t)]);
-		case TFun(args, ret):
-			return TFun([for( a in args ) { name : a.name, opt : a.opt, t : f(a.t) }], f(ret));
-		case TAnon(fields):
-			return TAnon([for( af in fields ) { name : af.name, opt : af.opt, t : f(af.t) }]);
-		case TLazy(l):
-			return f(l());
-		}
-	}
+    public function mapType( t : TType, f : TType -> TType ) {
+        switch (t) {
+        case TMono(r):
+            if( r.r == null ) return t;
+            return f(t);
+        case TVoid, TInt, TFloat,TBool,TDynamic,TParam(_), TUnresolved(_):
+            return t;
+        case TEnum(_,[]), TInst(_,[]), TAbstract(_,[]), TType(_,[]):
+            return t;
+        case TNull(t):
+            return TNull(f(t));
+        case TInst(c, args):
+            return TInst(c, [for( t in args ) f(t)]);
+        case TEnum(e, args):
+            return TEnum(e, [for( t in args ) f(t)]);
+        case TType(t, args):
+            return TType(t, [for( t in args ) f(t)]);
+        case TAbstract(a, args):
+            return TAbstract(a, [for( t in args ) f(t)]);
+        case TFun(args, ret):
+            return TFun([for( a in args ) { name : a.name, opt : a.opt, t : f(a.t) }], f(ret));
+        case TAnon(fields):
+            return TAnon([for( af in fields ) { name : af.name, opt : af.opt, t : f(af.t) }]);
+        case TLazy(l):
+            return f(l());
+        }
+    }
 
-	public function follow( t : TType ) {
+    public function follow( t : TType ) {
 		return switch( t ) {
 		case TMono(r): if( r.r != null ) follow(r.r) else t;
 		case TType(t,args): follow(apply(t.t, t.params, args));
@@ -808,434 +814,434 @@ class Checker {
 		}
 	}
 
-	public function unasync( t : TType ) : TType {
-		switch( follow(t) ) {
-		case TFun(args, ret) if( args.length > 0 ):
-			var rargs = args.copy();
-			switch( follow(rargs.shift().t) ) {
-			case TFun([r],_): return TFun(rargs,r.t);
-			default:
-			}
-		default:
-		}
-		return null;
-	}
+    public function unasync( t : TType ) : TType {
+        switch( follow(t) ) {
+        case TFun(args, ret) if( args.length > 0 ):
+            var rargs = args.copy();
+            switch( follow(rargs.shift().t) ) {
+            case TFun([r],_): return TFun(rargs,r.t);
+            default:
+            }
+        default:
+        }
+        return null;
+    }
 
-	function typeExprWith( expr : Expr, t : TType ) {
-		var et = typeExpr(expr, WithType(t));
-		unify(et, t, expr);
-		return t;
-	}
+    function typeExprWith( expr : Expr, t : TType ) {
+        var et = typeExpr(expr, WithType(t));
+        unify(et, t, expr);
+        return t;
+    }
 
-	function makeMono() {
-		return TMono({r:null});
-	}
+    function makeMono() {
+        return TMono({r:null});
+    }
 
-	function makeIterator(t) : TType {
-		return TAnon([{ name : "next", opt : false, t : TFun([],t) }, { name : "hasNext", opt : false, t : TFun([],TBool) }]);
-	}
+    function makeIterator(t) : TType {
+        return TAnon([{ name : "next", opt : false, t : TFun([],t) }, { name : "hasNext", opt : false, t : TFun([],TBool) }]);
+    }
 
-	function mk(e,p) : Expr {
-		#if hscriptPos
-		return { e : e, pmin : p.pmin, pmax : p.pmax, origin : p.origin, line : p.line };
-		#else
-		return e;
-		#end
-	}
+    function mk(e,p) : Expr {
+        #if hscriptPos
+        return { e : e, pmin : p.pmin, pmax : p.pmax, origin : p.origin, line : p.line };
+        #else
+        return e;
+        #end
+    }
 
-	function isString( t : TType ) {
-		t = follow(t);
-		return t.match(TInst({name:"String"},_));
-	}
+    function isString( t : TType ) {
+        t = follow(t);
+        return t.match(TInst({name:"String"},_));
+    }
 
-	function onCompletion( expr : Expr, t : TType ) {
-		if( isCompletion ) throw new Completion(expr, t);
-	}
+    function onCompletion( expr : Expr, t : TType ) {
+        if( isCompletion ) throw new Completion(expr, t);
+    }
 
-	function typeField( o : Expr, f : String, expr : Expr, forWrite : Bool ) {
-		var ot = typeExpr(o, Value);
-		if( f == null )
-			onCompletion(expr, ot);
-		var ft = getField(ot, f, expr, forWrite);
-		if( ft == null ) {
-			error(typeStr(ot)+" has no field "+f, expr);
-			ft = TDynamic;
-		}
-		return ft;
-	}
+    function typeField( o : Expr, f : String, expr : Expr, forWrite : Bool ) {
+        var ot = typeExpr(o, Value);
+        if( f == null )
+            onCompletion(expr, ot);
+        var ft = getField(ot, f, expr, forWrite);
+        if( ft == null ) {
+            error(typeStr(ot)+" has no field "+f, expr);
+            ft = TDynamic;
+        }
+        return ft;
+    }
 
-	function typeExpr( expr : Expr, withType : WithType ) : TType {
-		if( expr == null && isCompletion )
-			return switch( withType ) {
-			case WithType(t): t;
-			default: TDynamic;
-			}
-		switch( edef(expr) ) {
-		case EConst(c):
-			return switch (c) {
-			case CInt(_): TInt;
-			case CFloat(_): TFloat;
-			case CString(_): types.t_string;
-			}
-		case EIdent(v):
-			var l = locals.get(v);
-			if( l != null ) return l;
-			var g = globals.get(v);
-			if( g != null ) {
-				return switch( g ) {
-				case TLazy(f): f();
-				default: g;
-				}
-			}
-			if( allowAsync ) {
-				g = globals.get("a_"+v);
-				if( g != null ) g = unasync(g);
-				if( g != null ) return g;
-			}
-			switch( v ) {
-			case "null":
-				return makeMono();
-			case "true", "false":
-				return TBool;
-			case "trace":
-				return TDynamic;
-			default:
-				if( isCompletion) return TDynamic;
-				error("Unknown identifier "+v, expr);
-			}
-		case EBlock(el):
-			var t = TVoid;
-			var locals = saveLocals();
-			for( e in el )
-				t = typeExpr(e, e == el[el.length-1] ? withType : NoValue);
-			this.locals = locals;
-			return t;
-		case EVar(n, t, init):
-			var vt = t == null ? makeMono() : makeType(t, expr);
-			if( init != null ) {
-				var et = typeExpr(init, t == null ? Value : WithType(vt));
-				if( t == null ) vt = et else unify(et,vt, init);
-			}
-			locals.set(n, vt);
-			return TVoid;
-		case EParent(e):
-			return typeExpr(e,withType);
-		case ECall(e, params):
-			var ft = typeExpr(e, Value);
-			switch( follow(ft) ) {
-			case TFun(args, ret):
-				for( i in 0...params.length ) {
-					var a = args[i];
-					if( a == null ) {
-						error("Too many arguments", params[i]);
-						break;
-					}
-					var t = typeExpr(params[i], a == null ? Value : WithType(a.t));
-					unify(t, a.t, params[i]);
-				}
-				for( i in params.length...args.length )
-					if( !args[i].opt )
-						error("Missing argument "+args[i].name+":"+typeStr(args[i].t), expr);
-				return ret;
-			case TDynamic:
-				for( p in params ) typeExpr(p,Value);
-				return makeMono();
-			default:
-				error(typeStr(ft)+" cannot be called", e);
-				return makeMono();
-			}
-		case EField(o, f):
-			return typeField(o,f,expr,false);
-		case ECheckType(v, t):
-			var ct = makeType(t, expr);
-			var vt = typeExpr(v, WithType(ct));
-			unify(vt, ct, v);
-			return ct;
-		case EMeta(m, _, e):
-			if( m == ":untyped" && allowUntypedMeta )
-				return makeMono();
-			return typeExpr(e, withType);
-		case EIf(cond, e1, e2), ETernary(cond, e1, e2):
-			typeExprWith(cond, TBool);
-			var t1 = typeExpr(e1, withType);
-			if( e2 == null )
-				return t1;
-			var t2 = typeExpr(e2, withType);
-			if( withType == NoValue )
-				return TVoid;
-			if( tryUnify(t2,t1) )
-				return t1;
-			if( tryUnify(t1,t2) )
-				return t2;
-			unify(t2,t1,e2); // error
-		case EWhile(cond, e), EDoWhile(cond, e):
-			typeExprWith(cond,TBool);
-			typeExpr(e, NoValue);
-			return TVoid;
-		case EObject(fl):
-			switch( withType ) {
-			case WithType(follow(_) => TAnon(tfields)) if( tfields.length > 0 ):
-				var map = [for( f in tfields ) f.name => f];
-				return TAnon([for( f in fl ) {
-					var ft = map.get(f.name);
-					var ft = if( ft == null ) {
-						error("Extra field "+f.name, f.e);
-						TDynamic;
-					} else ft.t;
-					{ t : typeExprWith(f.e, ft), opt : false, name : f.name }
-				}]);
-			default:
-				return TAnon([for( f in fl ) { t : typeExpr(f.e, Value), opt : false, name : f.name }]);
-			}
-		case EBreak, EContinue:
-			return TVoid;
-		case EReturn(v):
-			var et = v == null ? TVoid : typeExpr(v, allowReturn == null ? Value : WithType(allowReturn));
-			if( allowReturn == null )
-				error("Return not allowed here", expr);
-			else
-				unify(et, allowReturn, v == null ? expr : v);
-			return makeMono();
-		case EArrayDecl(el):
-			var et = null;
-			for( v in el ) {
-				var t = typeExpr(v, et == null ? Value : WithType(et));
-				if( et == null ) et = t else if( !tryUnify(t,et) ) {
-					if( tryUnify(et,t) ) et = t else unify(t,et,v);
-				}
-			}
-			if( et == null ) et = makeMono();
-			return types.getType("Array",[et]);
-		case EArray(a, index):
-			typeExprWith(index, TInt);
-			var at = typeExpr(a, Value);
-			switch( follow(at) ) {
-			case TInst({ name : "Array"},[et]): return et;
-			default: error(typeStr(at)+" is not an Array", a);
-			}
-		case EThrow(e):
-			typeExpr(e, Value);
-			return makeMono();
-		case EFunction(args, body, name, ret):
-			var ft = null, tret = null, targs = null;
-			if( currentFunType != null ) {
-				switch( currentFunType ) {
-				case TFun(args,ret):
-					ft = currentFunType;
-					tret = ret; targs = args;
-				default:
-					throw "assert";
-				}
-				currentFunType = null;
-			} else {
-				tret = ret == null ? makeMono() : makeType(ret, expr);
-			}
-			var locals = saveLocals();
-			var oldRet = allowReturn;
-			var oldGDef = allowDefine;
-			allowReturn = tret;
-			allowDefine = false;
-			var withArgs = null;
-			if( name != null && !withType.match(WithType(follow(_) => TFun(_))) ) {
-				var ev = events.get(name);
-				if( ev != null ) withType = WithType(ev);
-			}
-			switch( withType ) {
-			case WithType(follow(_) => TFun(args,ret)): withArgs = args; unify(tret,ret,expr);
-			default:
-			}
-			if( targs == null )
-				targs = typeArgs(args,expr);
-			for( i in 0...targs.length ) {
-				var a = targs[i];
-				if( withArgs != null ) {
-					if( i < withArgs.length )
-						unify(withArgs[i].t, a.t, expr);
-					else
-						error("Extra argument "+a.name, expr);
-				}
-				this.locals.set(a.name, a.t);
-			}
-			if( withArgs != null && targs.length < withArgs.length )
-				error("Missing "+(withArgs.length - targs.length)+" arguments ("+[for( i in targs.length...withArgs.length ) typeStr(withArgs[i].t)].join(",")+")", expr);
-			typeExpr(body,NoValue);
-			allowDefine = oldGDef;
-			allowReturn = oldRet;
-			this.locals = locals;
-			if( ft == null ) {
-				ft = TFun(targs, tret);
-				locals.set(name, ft);
-			}
-			return ft;
-		case EUnop(op, _, e):
-			var et = typeExpr(e, Value);
-			switch( op ) {
-			case "++", "--", "-":
-				unify(et,TInt,e);
-				return et;
-			case "!":
-				unify(et,TBool,e);
-				return et;
-			default:
-			}
-		case EFor(v, it, e):
-			var locals = saveLocals();
-			var itt = typeExpr(it, Value);
-			var vt = switch( follow(itt) ) {
-			case TInst({name:"Array"},[t]):
-				t;
-			default:
-				var ft = getField(itt,"iterator", it);
-				if( ft == null )
-					switch( itt ) {
-					case TAbstract(a, args):
-						// special case : we allow unconditional access
-						// to an abstract iterator() underlying value (eg: ArrayProxy)
-						ft = getField(apply(a.t,a.params,args),"iterator",it);
-					default:
-					}
-				if( ft != null )
-					switch( ft ) {
-					case TFun([],ret): ft = ret;
-					default: ft = null;
-					}
-				var t = makeMono();
-				var iter = makeIterator(t);
-				unify(ft != null ? ft : itt,iter,it);
-				t;
-			}
-			this.locals.set(v, vt);
-			typeExpr(e, NoValue);
-			this.locals = locals;
-			return TVoid;
-		case EBinop(op, e1, e2):
-			switch( op ) {
-			case "&", "|", "^", ">>", ">>>", "<<":
-				typeExprWith(e1,TInt);
-				typeExprWith(e2,TInt);
-				return TInt;
-			case "=":
-				if( allowDefine ) {
-					switch( edef(e1) ) {
-					case EIdent(i) if( !locals.exists(i) && !globals.exists(i) ):
-						var vt = typeExpr(e2,Value);
-						locals.set(i, vt);
-						return vt;
-					default:
-					}
-				}
-				var vt = switch( edef(e1) ) {
-				case EField(o,f): typeField(o, f, e1, true);
-				default: typeExpr(e1,Value);
-				}
-				typeExprWith(e2,vt);
-				return vt;
-			case "+":
-				var t1 = typeExpr(e1,WithType(TInt));
-				var t2 = typeExpr(e2,WithType(t1));
-				tryUnify(t1,t2);
-				switch( [follow(t1), follow(t2)]) {
-				case [TInt, TInt]:
-					return TInt;
-				case [TFloat, TInt], [TInt, TFloat], [TFloat, TFloat]:
-					return TFloat;
-				case [TDynamic, _], [_, TDynamic]:
-					return TDynamic;
-				case [t1,t2]:
-					if( isString(t1) || isString(t2) )
-						return types.t_string;
-					unify(t1, TFloat, e1);
-					unify(t2, TFloat, e2);
-				}
-			case "-", "*", "/", "%":
-				var t1 = typeExpr(e1,WithType(TInt));
-				var t2 = typeExpr(e2,WithType(t1));
-				if( !tryUnify(t1,t2) )
-					unify(t2,t1,e2);
-				switch( [follow(t1), follow(t2)]) {
-				case [TInt, TInt]:
-					if( op == "/" ) return TFloat;
-					return TInt;
-				case [TFloat|TDynamic, TInt|TDynamic], [TInt|TDynamic, TFloat|TDynamic], [TFloat, TFloat]:
-					return TFloat;
-				default:
-					unify(t1, TFloat, e1);
-					unify(t2, TFloat, e2);
-				}
-			case "&&", "||":
-				typeExprWith(e1,TBool);
-				typeExprWith(e2,TBool);
-				return TBool;
-			case "...":
-				typeExprWith(e1,TInt);
-				typeExprWith(e2,TInt);
-				return makeIterator(TInt);
-			case "==", "!=":
-				var t1 = typeExpr(e1,Value);
-				var t2 = typeExpr(e2,WithType(t1));
-				if( !tryUnify(t1,t2) )
-					unify(t2,t1,e2);
-				return TBool;
-			case ">", "<", ">=", "<=":
-				var t1 = typeExpr(e1,Value);
-				var t2 = typeExpr(e2,WithType(t1));
-				if( !tryUnify(t1,t2) )
-					unify(t2,t1,e2);
-				switch( follow(t1) ) {
-				case TInt, TFloat, TBool, TInst({name:"String"},_):
-				default:
-					error("Cannot compare "+typeStr(t1), expr);
-				}
-				return TBool;
-			default:
-				if( op.charCodeAt(op.length-1) == "=".code ) {
-					var t = typeExpr(mk(EBinop(op.substr(0,op.length-1),e1,e2),expr),withType);
-					return typeExpr(mk(EBinop("=",e1,e2),expr), withType);
-				}
-				error("Unsupported operation "+op, expr);
-			}
-		case ETry(etry, v, et, ecatch):
-			var vt = typeExpr(etry, withType);
+    function typeExpr( expr : Expr, withType : WithType ) : TType {
+        if( expr == null && isCompletion )
+            return switch( withType ) {
+            case WithType(t): t;
+            default: TDynamic;
+            }
+        switch( edef(expr) ) {
+        case EConst(c):
+            return switch (c) {
+            case CInt(_): TInt;
+            case CFloat(_): TFloat;
+            case CString(_): types.t_string;
+            }
+        case EIdent(v):
+            var l = locals.get(v);
+            if( l != null ) return l;
+            var g = globals.get(v);
+            if( g != null ) {
+                return switch( g ) {
+                case TLazy(f): f();
+                default: g;
+                }
+            }
+            if( allowAsync ) {
+                g = globals.get("a_"+v);
+                if( g != null ) g = unasync(g);
+                if( g != null ) return g;
+            }
+            switch( v ) {
+            case "null":
+                return makeMono();
+            case "true", "false":
+                return TBool;
+            case "trace":
+                return TDynamic;
+            default:
+                if( isCompletion) return TDynamic;
+                error("Unknown identifier "+v+' $expr', expr);
+            }
+        case EBlock(el):
+            var t = TVoid;
+            var locals = saveLocals();
+            for( e in el )
+                t = typeExpr(e, e == el[el.length-1] ? withType : NoValue);
+            this.locals = locals;
+            return t;
+        case EVar(n, t, init):
+            var vt = t == null ? makeMono() : makeType(t, expr);
+            if( init != null ) {
+                var et = typeExpr(init, t == null ? Value : WithType(vt));
+                if( t == null ) vt = et else unify(et,vt, init);
+            }
+            locals.set(n, vt);
+            return TVoid;
+        case EParent(e):
+            return typeExpr(e,withType);
+        case ECall(e, params):
+            var ft = typeExpr(e, Value);
+            switch( follow(ft) ) {
+            case TFun(args, ret):
+                for( i in 0...params.length ) {
+                    var a = args[i];
+                    if( a == null ) {
+                        error("Too many arguments", params[i]);
+                        break;
+                    }
+                    var t = typeExpr(params[i], a == null ? Value : WithType(a.t));
+                    unify(t, a.t, params[i]);
+                }
+                for( i in params.length...args.length )
+                    if( !args[i].opt )
+                        error("Missing argument "+args[i].name+":"+typeStr(args[i].t), expr);
+                return ret;
+            case TDynamic:
+                for( p in params ) typeExpr(p,Value);
+                return makeMono();
+            default:
+                error(typeStr(ft)+" cannot be called", e);
+                return makeMono();
+            }
+        case EField(o, f):
+            return typeField(o,f,expr,false);
+        case ECheckType(v, t):
+            var ct = makeType(t, expr);
+            var vt = typeExpr(v, WithType(ct));
+            unify(vt, ct, v);
+            return ct;
+        case EMeta(m, _, e):
+            if( m == ":untyped" && allowUntypedMeta )
+                return makeMono();
+            return typeExpr(e, withType);
+        case EIf(cond, e1, e2), ETernary(cond, e1, e2):
+            typeExprWith(cond, TBool);
+            var t1 = typeExpr(e1, withType);
+            if( e2 == null )
+                return t1;
+            var t2 = typeExpr(e2, withType);
+            if( withType == NoValue )
+                return TVoid;
+            if( tryUnify(t2,t1) )
+                return t1;
+            if( tryUnify(t1,t2) )
+                return t2;
+            unify(t2,t1,e2); // error
+        case EWhile(cond, e), EDoWhile(cond, e):
+            typeExprWith(cond,TBool);
+            typeExpr(e, NoValue);
+            return TVoid;
+        case EObject(fl):
+            switch( withType ) {
+                case WithType(follow(_) => TAnon(tfields)) if( tfields.length > 0 ):
+                var map = [for( f in tfields ) f.name => f];
+                return TAnon([for( f in fl ) {
+                    var ft = map.get(f.name);
+                    var ft = if( ft == null ) {
+                        error("Extra field "+f.name, f.e);
+                        TDynamic;
+                    } else ft.t;
+                    { t : typeExprWith(f.e, ft), opt : false, name : f.name }
+                }]);
+            default:
+                return TAnon([for( f in fl ) { t : typeExpr(f.e, Value), opt : false, name : f.name }]);
+            }
+        case EBreak, EContinue:
+            return TVoid;
+        case EReturn(v):
+            var et = v == null ? TVoid : typeExpr(v, allowReturn == null ? Value : WithType(allowReturn));
+            if( allowReturn == null )
+                error("Return not allowed here", expr);
+            else
+                unify(et, allowReturn, v == null ? expr : v);
+            return makeMono();
+        case EArrayDecl(el):
+            var et = null;
+            for( v in el ) {
+                var t = typeExpr(v, et == null ? Value : WithType(et));
+                if( et == null ) et = t else if( !tryUnify(t,et) ) {
+                    if( tryUnify(et,t) ) et = t else unify(t,et,v);
+                }
+            }
+            if( et == null ) et = makeMono();
+            return types.getType("Array",[et]);
+        case EArray(a, index):
+            typeExprWith(index, TInt);
+            var at = typeExpr(a, Value);
+            switch( follow(at) ) {
+            case TInst({ name : "Array"},[et]): return et;
+            default: error(typeStr(at)+" is not an Array", a);
+            }
+        case EThrow(e):
+            typeExpr(e, Value);
+            return makeMono();
+        case EFunction(args, body, name, ret):
+            var ft = null, tret = null, targs = null;
+            if( currentFunType != null ) {
+                switch( currentFunType ) {
+                case TFun(args,ret):
+                    ft = currentFunType;
+                    tret = ret; targs = args;
+                default:
+                    throw "assert";
+                }
+                currentFunType = null;
+            } else {
+                tret = ret == null ? makeMono() : makeType(ret, expr);
+            }
+            var locals = saveLocals();
+            var oldRet = allowReturn;
+            var oldGDef = allowDefine;
+            allowReturn = tret;
+            allowDefine = false;
+            var withArgs = null;
+            if( name != null && !withType.match(WithType(follow(_) => TFun(_))) ) {
+                var ev = events.get(name);
+                if( ev != null ) withType = WithType(ev);
+            }
+            switch( withType ) {
+            case WithType(follow(_) => TFun(args,ret)): withArgs = args; unify(tret,ret,expr);
+            default:
+            }
+            if( targs == null )
+                targs = typeArgs(args,expr);
+            for( i in 0...targs.length ) {
+                var a = targs[i];
+                if( withArgs != null ) {
+                    if( i < withArgs.length )
+                        unify(withArgs[i].t, a.t, expr);
+                    else
+                        error("Extra argument "+a.name, expr);
+                }
+                this.locals.set(a.name, a.t);
+            }
+            if( withArgs != null && targs.length < withArgs.length )
+                error("Missing "+(withArgs.length - targs.length)+" arguments ("+[for( i in targs.length...withArgs.length ) typeStr(withArgs[i].t)].join(",")+")", expr);
+            typeExpr(body,NoValue);
+            allowDefine = oldGDef;
+            allowReturn = oldRet;
+            this.locals = locals;
+            if( ft == null ) {
+                ft = TFun(targs, tret);
+                locals.set(name, ft);
+            }
+            return ft;
+        case EUnop(op, _, e):
+            var et = typeExpr(e, Value);
+            switch( op ) {
+            case "++", "--", "-", "~":
+                unify(et,TInt,e);
+                return et;
+            case "!":
+                unify(et,TBool,e);
+                return et;
+            default:
+            }
+        case EFor(v, it, e):
+            var locals = saveLocals();
+            var itt = typeExpr(it, Value);
+            var vt = switch( follow(itt) ) {
+            case TInst({name:"Array"},[t]):
+                t;
+            default:
+                var ft = getField(itt,"iterator", it);
+                if( ft == null )
+                    switch( itt ) {
+                    case TAbstract(a, args):
+                        // special case : we allow unconditional access
+                        // to an abstract iterator() underlying value (eg: ArrayProxy)
+                        ft = getField(apply(a.t,a.params,args),"iterator",it);
+                    default:
+                    }
+                if( ft != null )
+                    switch( ft ) {
+                    case TFun([],ret): ft = ret;
+                    default: ft = null;
+                    }
+                var t = makeMono();
+                var iter = makeIterator(t);
+                unify(ft != null ? ft : itt,iter,it);
+                t;
+            }
+            this.locals.set(v, vt);
+            typeExpr(e, NoValue);
+            this.locals = locals;
+            return TVoid;
+        case EBinop(op, e1, e2):
+            switch( op ) {
+            case "&", "|", "^", ">>", ">>>", "<<":
+                typeExprWith(e1,TInt);
+                typeExprWith(e2,TInt);
+                return TInt;
+            case "=":
+                if( allowDefine ) {
+                    switch( edef(e1) ) {
+                    case EIdent(i) if( !locals.exists(i) && !globals.exists(i) ):
+                        var vt = typeExpr(e2,Value);
+                        locals.set(i, vt);
+                        return vt;
+                    default:
+                    }
+                }
+                var vt = switch( edef(e1) ) {
+                case EField(o,f): typeField(o, f, e1, true);
+                default: typeExpr(e1,Value);
+                }
+                typeExprWith(e2,vt);
+                return vt;
+            case "+":
+                var t1 = typeExpr(e1,WithType(TInt));
+                var t2 = typeExpr(e2,WithType(t1));
+                tryUnify(t1,t2);
+                switch( [follow(t1), follow(t2)]) {
+                case [TInt, TInt]:
+                    return TInt;
+                case [TFloat, TInt], [TInt, TFloat], [TFloat, TFloat]:
+                    return TFloat;
+                case [TDynamic, _], [_, TDynamic]:
+                    return TDynamic;
+                case [t1,t2]:
+                    if( isString(t1) || isString(t2) )
+                        return types.t_string;
+                    unify(t1, TFloat, e1);
+                    unify(t2, TFloat, e2);
+                }
+            case "-", "*", "/", "%":
+                var t1 = typeExpr(e1,WithType(TInt));
+                var t2 = typeExpr(e2,WithType(t1));
+                if( !tryUnify(t1,t2) )
+                    unify(t2,t1,e2);
+                switch( [follow(t1), follow(t2)]) {
+                case [TInt, TInt]:
+                    if( op == "/" ) return TFloat;
+                    return TInt;
+                case [TFloat|TDynamic, TInt|TDynamic], [TInt|TDynamic, TFloat|TDynamic], [TFloat, TFloat]:
+                    return TFloat;
+                default:
+                    unify(t1, TFloat, e1);
+                    unify(t2, TFloat, e2);
+                }
+            case "&&", "||":
+                typeExprWith(e1,TBool);
+                typeExprWith(e2,TBool);
+                return TBool;
+            case "...":
+                typeExprWith(e1,TInt);
+                typeExprWith(e2,TInt);
+                return makeIterator(TInt);
+            case "==", "!=":
+                var t1 = typeExpr(e1,Value);
+                var t2 = typeExpr(e2,WithType(t1));
+                if( !tryUnify(t1,t2) )
+                    unify(t2,t1,e2);
+                return TBool;
+            case ">", "<", ">=", "<=":
+                var t1 = typeExpr(e1,Value);
+                var t2 = typeExpr(e2,WithType(t1));
+                if( !tryUnify(t1,t2) )
+                    unify(t2,t1,e2);
+                switch( follow(t1) ) {
+                case TInt, TFloat, TBool, TInst({name:"String"},_):
+                default:
+                    error("Cannot compare "+typeStr(t1), expr);
+                }
+                return TBool;
+            default:
+                if( op.charCodeAt(op.length-1) == "=".code ) {
+                    var t = typeExpr(mk(EBinop(op.substr(0,op.length-1),e1,e2),expr),withType);
+                    return typeExpr(mk(EBinop("=",e1,e2),expr), withType);
+                }
+                error("Unsupported operation "+op, expr);
+            }
+        case ETry(etry, v, et, ecatch):
+            var vt = typeExpr(etry, withType);
 
-			var old = locals.get(v);
-			locals.set(v, makeType(et, ecatch));
-			var ct = typeExpr(ecatch, withType);
-			if( old != null ) locals.set(v,old) else locals.remove(v);
+            var old = locals.get(v);
+            locals.set(v, makeType(et, ecatch));
+            var ct = typeExpr(ecatch, withType);
+            if( old != null ) locals.set(v,old) else locals.remove(v);
 
-			if( withType == NoValue )
-				return TVoid;
-			if( tryUnify(vt,ct) )
-				return ct;
-			unify(ct,vt,ecatch);
-			return vt;
-		case ESwitch(value, cases, defaultExpr):
-			var tmin = null;
-			var vt = typeExpr(value, Value);
-			inline function mergeType(t,p) {
-				if( withType != NoValue ) {
-					if( tmin == null )
-						tmin = t;
-					else if( !tryUnify(t,tmin) ) {
-						unify(tmin,t, p);
-						tmin = t;
-					}
-				}
-			}
-			for( c in cases ) {
-				for( v in c.values ) {
-					var ct = typeExpr(v, WithType(vt));
-					unify(ct, vt, v);
-				}
-				var et = typeExpr(c.expr, withType);
-				mergeType(et, c.expr);
-			}
-			if( defaultExpr != null )
-				mergeType( typeExpr(defaultExpr, withType), defaultExpr);
-			return withType == NoValue ? TVoid : tmin == null ? makeMono() : tmin;
-		case ENew(cl, params):
-		}
-		error("Don't know how to type "+edef(expr).getName(), expr);
-		return TDynamic;
-	}
+            if( withType == NoValue )
+                return TVoid;
+            if( tryUnify(vt,ct) )
+                return ct;
+            unify(ct,vt,ecatch);
+            return vt;
+        case ESwitch(value, cases, defaultExpr):
+            var tmin = null;
+            var vt = typeExpr(value, Value);
+            inline function mergeType(t,p) {
+                if( withType != NoValue ) {
+                    if( tmin == null )
+                        tmin = t;
+                    else if( !tryUnify(t,tmin) ) {
+                        unify(tmin,t, p);
+                        tmin = t;
+                    }
+                }
+            }
+            for( c in cases ) {
+                for( v in c.values ) {
+                    var ct = typeExpr(v, WithType(vt));
+                    unify(ct, vt, v);
+                }
+                var et = typeExpr(c.expr, withType);
+                mergeType(et, c.expr);
+            }
+            if( defaultExpr != null )
+                mergeType( typeExpr(defaultExpr, withType), defaultExpr);
+            return withType == NoValue ? TVoid : tmin == null ? makeMono() : tmin;
+        case ENew(cl, params):
+        }
+        error("Don't know how to type "+edef(expr).getName(), expr);
+        return TDynamic;
+    }
 
 }

--- a/hscript/Expr.hx
+++ b/hscript/Expr.hx
@@ -125,6 +125,10 @@ enum ModuleDecl {
 	DImport( path : Array<String>, ?everything : Bool );
 	DClass( c : ClassDecl );
 	DTypedef( c : TypeDecl );
+    DAbstract(a:AbstractDecl);
+    DEnum(e:EnumDecl);
+    DInterface(i:InterfaceDecl);
+
 }
 
 typedef ModuleType = {
@@ -133,17 +137,29 @@ typedef ModuleType = {
 	var meta : Metadata;
 	var isPrivate : Bool;
 }
+typedef InstancedType = {>ModuleType,
+    var fields : Array<FieldDecl>;
+	var isExtern : Bool;
+}
 
-typedef ClassDecl = {> ModuleType,
+typedef ClassDecl = {> InstancedType,
 	var extend : Null<CType>;
 	var implement : Array<CType>;
-	var fields : Array<FieldDecl>;
-	var isExtern : Bool;
+}
+typedef InterfaceDecl = {>InstancedType,
+    var extend : Array<CType>;
 }
 
 typedef TypeDecl = {> ModuleType,
 	var t : CType;
 }
+typedef AbstractDecl = {>InstancedType,
+    var t:CType;
+    var to:Array<CType>;
+    var from:Array<CType>;
+}
+typedef EnumDecl = InstancedType;
+
 
 typedef FieldDecl = {
 	var name : String;

--- a/hscript/Expr.hx
+++ b/hscript/Expr.hx
@@ -83,6 +83,8 @@ enum CType {
 	CTParent( t : CType );
 	CTOpt( t : CType );
 	CTNamed( n : String, t : CType );
+
+    CTParam(p:String);
 }
 
 #if hscriptPos

--- a/hscript/Expr.hx
+++ b/hscript/Expr.hx
@@ -185,7 +185,7 @@ enum FieldKind {
 }
 
 typedef TypeParamDecl = {
-    @:optional var params : Array<TypeParamDecl>; // what even..
+    @:optional var params : Params; // what even..
     var name:String;
     @:optional var meta:Metadata;
     @:optional var constraints:Array<CType>; // probably not right

--- a/hscript/Expr.hx
+++ b/hscript/Expr.hx
@@ -57,7 +57,7 @@ enum Expr {
 	EFor( v : String, it : Expr, e : Expr );
 	EBreak;
 	EContinue;
-	EFunction( args : Array<Argument>, e : Expr, ?name : String, ?ret : CType );
+	EFunction( k:FunctionKind, f:FunctionDecl );
 	EReturn( ?e : Expr );
 	EArray( e : Expr, index : Expr );
 	EArrayDecl( e : Array<Expr> );
@@ -72,7 +72,7 @@ enum Expr {
 	ECheckType( e : Expr, t : CType );
 }
 
-typedef Argument = { name : String, ?t : CType, ?opt : Bool, ?value : Expr };
+typedef Argument = { name : String, ?t : CType, ?opt : Bool, ?value : Expr, ?meta:Metadata };
 
 typedef Metadata = Array<{ name : String, params : Array<Expr> }>;
 
@@ -173,7 +173,6 @@ typedef FieldDecl = {
 enum FieldAccess {
 	APublic;
 	APrivate;
-	AInline;
 	AOverride;
 	AStatic;
 	AMacro;
@@ -184,12 +183,24 @@ enum FieldKind {
 	KVar( v : VarDecl );
 }
 
-typedef FunctionDecl = {
-	var args : Array<Argument>;
-	var expr : Expr;
-	var ret : Null<CType>;
+typedef TypeParamDecl = {
+    @:optional var params : Array<TypeParamDecl>; // what even..
+    var name:String;
+    @:optional var meta:Metadata;
+    @:optional var constraints:Array<CType>; // probably not right
+}
+enum FunctionKind {
+    FAnonymous;
+    FNamed(name:String, inlined:Bool);
+    FArrow;
 }
 
+typedef FunctionDecl = {
+	var args : Array<Argument>;
+    @:optional var params : Array<TypeParamDecl>;
+	var expr : Expr;
+	@:optional var ret : Null<CType>;
+}
 typedef VarDecl = {
 	var get : Null<String>;
 	var set : Null<String>;

--- a/hscript/Expr.hx
+++ b/hscript/Expr.hx
@@ -198,7 +198,7 @@ enum FunctionKind {
 
 typedef FunctionDecl = {
 	var args : Array<Argument>;
-    @:optional var params : Array<TypeParamDecl>;
+    @:optional var params : Params;
 	var expr : Expr;
 	@:optional var ret : Null<CType>;
 }

--- a/hscript/Expr.hx
+++ b/hscript/Expr.hx
@@ -84,7 +84,7 @@ enum CType {
 	CTOpt( t : CType );
 	CTNamed( n : String, t : CType );
 
-    CTParam(p:String);
+    CTParam(p:String, index:Int);
 }
 
 #if hscriptPos

--- a/hscript/Expr.hx
+++ b/hscript/Expr.hx
@@ -132,10 +132,10 @@ enum ModuleDecl {
     DInterface(i:InterfaceDecl);
 
 }
-
+typedef Params = Array<TypeParamDecl>;
 typedef ModuleType = {
 	var name : String;
-	var params : {}; // TODO : not yet parsed
+	var params : Params; // TODO : not yet parsed
 	var meta : Metadata;
 	var isPrivate : Bool;
 }
@@ -174,6 +174,7 @@ enum FieldAccess {
 	APublic;
 	APrivate;
 	AOverride;
+    AInline;
 	AStatic;
 	AMacro;
 }

--- a/hscript/Expr.hx
+++ b/hscript/Expr.hx
@@ -138,6 +138,7 @@ typedef ModuleType = {
 	var params : Params; // TODO : not yet parsed
 	var meta : Metadata;
 	var isPrivate : Bool;
+    @:optional var doc : String;
 }
 typedef InstancedType = {>ModuleType,
     var fields : Array<FieldDecl>;

--- a/hscript/Interp.hx
+++ b/hscript/Interp.hx
@@ -403,7 +403,7 @@ class Interp {
 		case EReturn(e):
 			returnValue = e == null ? null : expr(e);
 			throw SReturn;
-		case EFunction(params,fexpr,name,_):
+		case EFunction(Tools.getFunctionName(_) => name,{args: params,expr: fexpr}):
 			var capturedLocals = duplicate(locals);
 			var me = this;
 			var hasOpt = false, minParams = 0;

--- a/hscript/Macro.hx
+++ b/hscript/Macro.hx
@@ -116,7 +116,7 @@ class Macro {
 
 	function convertType( t : Expr.CType ) : ComplexType {
 		return switch( t ) {
-        case CTParam(p): TPath({name: p, pack: []});
+        case CTParam(p, _): TPath({name: p, pack: []});
 		case CTOpt(t): TOptional(convertType(t));
 		case CTPath(pack, args):
 			var params = [];

--- a/hscript/Macro.hx
+++ b/hscript/Macro.hx
@@ -116,6 +116,7 @@ class Macro {
 
 	function convertType( t : Expr.CType ) : ComplexType {
 		return switch( t ) {
+        case CTParam(p): TPath({name: p, pack: []});
 		case CTOpt(t): TOptional(convertType(t));
 		case CTPath(pack, args):
 			var params = [];

--- a/hscript/Macro.hx
+++ b/hscript/Macro.hx
@@ -209,7 +209,7 @@ class Macro {
 				EBreak;
 			case EContinue:
 				EContinue;
-			case EFunction(args, e, name, ret):
+			case EFunction(Tools.getFunctionName(_) => name, {args: args, expr: e, ret: ret}):
 				var targs = [];
 				for( a in args )
 					targs.push( {

--- a/hscript/Parser.hx
+++ b/hscript/Parser.hx
@@ -1209,11 +1209,12 @@ class Parser {
                             case CTPath(['Int'], _): mk(EConst(CInt(counter++)), readPos, readPos+1);
                             default: cast error(ECustom('expected variable initializer for $fieldName'), readPos, readPos+1);
                         }
+                        a.meta = [{name: ':enum', params: []}].concat(a.meta);
                         a.fields = [for(f in a.fields) switch f.kind {
-                            case KVar(v):
+                            case KVar(v) if(f.access.length == 0):
                                 {
                                     name: f.name,
-                                    meta: [{name: ':enum', params: []}].concat(f.meta),
+                                    meta: f.meta,
                                     kind: KVar({
                                         type: CTPath(a.name.split('.'), [for(param in a.params) CTParam(param.name)]),
                                         set: null,

--- a/hscript/Parser.hx
+++ b/hscript/Parser.hx
@@ -1086,10 +1086,33 @@ class Parser {
 	}
 
 	function parseParams():Params {
-		if( maybe(TOp("<")) )
-			error(EInvalidOp("Unsupported class type parameters"), readPos, readPos);
-		return  [];
+        var ret:Params = [];
+		if( maybe(TOp("<")) ) {
+            ret.push(parseParam());
+            while(!maybe(TOp(">"))) {
+                ensure(TComma);
+                ret.push(parseParam());
+            }
+        }
+		return  ret;
 	}
+    inline function parseParam():TypeParamDecl {
+        var params = [];
+        var meta = parseMetadata();
+        var name = getIdent();
+        var constraints = [];
+        if(maybe(TDoubleDot)) {
+            do {
+                constraints.push(parseType());
+            }while(maybe(TOp('&')));
+        }
+        return {
+            params: params,
+            meta: meta,
+            name: name,
+            constraints: constraints
+        };
+    }
     
 	function parseModuleDecl() : ModuleDecl {
 		var meta = parseMetadata();

--- a/hscript/Parser.hx
+++ b/hscript/Parser.hx
@@ -1119,7 +1119,7 @@ class Parser {
 		var meta = parseMetadata();
 		var ident = getIdent();
 		var isPrivate = false, isExtern = false;
-        inline function parseAbstract() {
+        function parseAbstract() {
             var name = getIdent();
             var params = parseParams();
             var underlying = null;
@@ -1231,7 +1231,7 @@ class Parser {
                         inline function fallbackInit(fieldName):Expr return switch a.t { // positions will be wrong
                             case CTPath(['String'], _): mk(EConst(CString(fieldName)), readPos, readPos+1);
                             case CTPath(['Int'], _): mk(EConst(CInt(counter++)), readPos, readPos+1);
-                            default: cast error(ECustom('expected variable initializer for $fieldName'), readPos, readPos+1);
+                            default: error(ECustom('expected variable initializer for $fieldName'), readPos, readPos+1); null;
                         }
                         a.meta = [{name: ':enum', params: []}].concat(a.meta);
                         a.fields = [for(f in a.fields) switch f.kind {
@@ -1250,7 +1250,7 @@ class Parser {
                             default: f;
                         }];
                         DAbstract(a);
-                    default: cast error(ECustom('assert'), readPos, readPos+1);
+                    default:error(ECustom('assert'), readPos, readPos+1); null;
                 }
                 
             } else {

--- a/hscript/Parser.hx
+++ b/hscript/Parser.hx
@@ -1216,7 +1216,7 @@ class Parser {
                                     name: f.name,
                                     meta: f.meta,
                                     kind: KVar({
-                                        type: CTPath(a.name.split('.'), [for(param in a.params) CTParam(param.name)]),
+                                        type: CTPath(a.name.split('.'), [for(i in 0...a.params.length) CTParam(a.params[i].name, i)]),
                                         set: null,
                                         get: null,
                                         expr: if(v.expr == null) fallbackInit(f.name) else v.expr

--- a/hscript/Parser.hx
+++ b/hscript/Parser.hx
@@ -1865,9 +1865,4 @@ class Parser {
 	}
 
 
-	
-
-	function getEnmAbstrVal(arg0:String, arg1:CType):Null<Expr> {
-		throw new haxe.exceptions.NotImplementedException();
-	}
 }

--- a/hscript/Printer.hx
+++ b/hscript/Printer.hx
@@ -48,6 +48,7 @@ class Printer {
 
 	function type( t : CType ) {
 		switch( t ) {
+        case null: 'Void';
         case CTParam(p, _):
             add(p);
 		case CTOpt(t):

--- a/hscript/Printer.hx
+++ b/hscript/Printer.hx
@@ -48,6 +48,8 @@ class Printer {
 
 	function type( t : CType ) {
 		switch( t ) {
+        case CTParam(p):
+            add(p);
 		case CTOpt(t):
 			add('?');
 			type(t);

--- a/hscript/Printer.hx
+++ b/hscript/Printer.hx
@@ -48,7 +48,7 @@ class Printer {
 
 	function type( t : CType ) {
 		switch( t ) {
-        case CTParam(p):
+        case CTParam(p, _):
             add(p);
 		case CTOpt(t):
 			add('?');

--- a/hscript/Printer.hx
+++ b/hscript/Printer.hx
@@ -209,7 +209,7 @@ class Printer {
 			add("break");
 		case EContinue:
 			add("continue");
-		case EFunction(params, e, name, ret):
+		case EFunction(Tools.getFunctionName(_) => name, {args: params, expr: e, ret:ret}):
 			add("function");
 			if( name != null )
 				add(" " + name);

--- a/hscript/Tools.hx
+++ b/hscript/Tools.hx
@@ -100,6 +100,7 @@ class Tools {
 
 	public static inline function mk( e : ExprDef, p : Expr ) {
 		#if hscriptPos
+        if(p == null) p = {pmin: 0, pmax: 0, origin: null, line: 0, e: null}; 
 		return { e : e, pmin : p.pmin, pmax : p.pmax, origin : p.origin, line : p.line };
 		#else
 		return e;

--- a/hscript/Tools.hx
+++ b/hscript/Tools.hx
@@ -39,7 +39,7 @@ class Tools {
 		case EDoWhile(c, e): f(c); f(e);
 		case EFor(_, it, e): f(it); f(e);
 		case EBreak,EContinue:
-		case EFunction(_, e, _, _): f(e);
+		case EFunction(_, {expr: e}): f(e);
 		case EReturn(e): if( e != null ) f(e);
 		case EArray(e, i): f(e); f(i);
 		case EArrayDecl(el): for( e in el ) f(e);
@@ -74,7 +74,7 @@ class Tools {
 		case EWhile(c, e): EWhile(f(c),f(e));
 		case EDoWhile(c, e): EDoWhile(f(c),f(e));
 		case EFor(v, it, e): EFor(v, f(it), f(e));
-		case EFunction(args, e, name, t): EFunction(args, f(e), name, t);
+		case EFunction(Tools.getFunctionName(_) => name, {args:args, expr: e, ret: t}): EFunction(getFunctionType(name), {args:args, expr: f(e), ret: t});
 		case EReturn(e): EReturn(if( e != null ) f(e) else null);
 		case EArray(e, i): EArray(f(e),f(i));
 		case EArrayDecl(el): EArrayDecl([for( e in el ) f(e)]);
@@ -106,5 +106,22 @@ class Tools {
 		return e;
 		#end
 	}
+    static var ANON = '_$$_anon_$$_';
+    static var ARROW = '_$$_arrow_$$_';
 
+	public static function getFunctionName(k:FunctionKind) {
+		return switch k {
+            case FAnonymous: ANON;
+            case FArrow: ARROW;
+            case FNamed(name, _): name;
+        }
+	}
+
+	public static function getFunctionType(name:String):FunctionKind {
+		return switch name {
+            case '$ANON'|null|'': FAnonymous;
+            case '$ARROW': FArrow;
+            case v: FNamed(v, false);
+        }
+	}
 }


### PR DESCRIPTION
This PR seeks to add full Haxe language support.

It also adds support for custom CheckerTypes collections (so as to allow importing types from other sources than Haxe RTTI XML API; e.g. from a .NET class library)

To-Do:
- Parsing
  - [X] Enums
  - [X] Abstracts
  - [X] Interfaces
  - [X] Enum Abstracts
  - [ ] Multiple var declarations
  - [X] Generic module decls
- Type-Checking
  - [X] Interfaces
  - [X] Enums (?)
  - [ ] Abstracts
  - [ ] Macro
- Interpreting (macro)
  - [ ] Enums
  - [ ] Pattern-matching
    - [ ] Structure-matching
    - [ ] Array matching
    - [ ] Enum Matching
    - [ ] Guards
    - [ ] Or patterns
    - [ ] Variable Capture
    - [ ] Extractors
  - [ ] Abstracts
  - [ ] Macros
     
      