### PR TITLE
Macro.hx if(!macro && hscriptPos) pos fix

### DIFF
--- a/hscript/Macro.hx
+++ b/hscript/Macro.hx
@@ -198,10 +198,10 @@ class Macro {
 				EWhile(convert(c), convert(e), false);
 			case EFor(v, it, efor):
 				#if (haxe_ver >= 4)
-					var p = #if hscriptPos { file : p.file, min : e.pmin, max : e.pmax } #else p #end;
+					var p = #if (!macro && hscriptPos) { file : p.file, min : e.pmin, max : e.pmax } #else p #end;
 					EFor({ expr : EBinop(OpIn,{ expr : EConst(CIdent(v)), pos : p },convert(it)), pos : p }, convert(efor));
 				#elseif (haxe_211 || haxe3)
-					var p = #if hscriptPos { file : p.file, min : e.pmin, max : e.pmax } #else p #end;
+					var p = #if (!macro && hscriptPos) { file : p.file, min : e.pmin, max : e.pmax } #else p #end;
 					EFor({ expr : EIn({ expr : EConst(CIdent(v)), pos : p },convert(it)), pos : p }, convert(efor));
 				#else
 					EFor(v, convert(it), convert(efor));
@@ -248,11 +248,11 @@ class Macro {
 			case ESwitch(e, cases, edef):
 				ESwitch(convert(e), [for( c in cases ) { values : [for( v in c.values ) convert(v)], expr : convert(c.expr) } ], edef == null ? null : convert(edef));
 			case EMeta(m, params, esub):
-				var mpos = #if hscriptPos { file : p.file, min : e.pmin, max : e.pmax } #else p #end;
+				var mpos = #if (!macro && hscriptPos) { file : p.file, min : e.pmin, max : e.pmax } #else p #end;
 				EMeta({ name : m, params : params == null ? [] : [for( p in params ) convert(p)], pos : mpos }, convert(esub));
 			case ECheckType(e, t):
 				ECheckType(convert(e), convertType(t));
-		}, pos : #if hscriptPos { file : p.file, min : e.pmin, max : e.pmax } #else p #end }
+		}, pos : #if (!macro && hscriptPos) { file : p.file, min : e.pmin, max : e.pmax } #else p #end }
 	}
 
 }

--- a/hscript/Macro.hx
+++ b/hscript/Macro.hx
@@ -219,7 +219,7 @@ class Macro {
 						opt : false,
 						value : null,
 					});
-				EFunction(#if haxe4 FNamed(name,false) #else name #end, {
+				EFunction(#if haxe4 name != null ? FNamed(name,false) : FAnonymous #else name #end, {
 					params : [],
 					args : targs,
 					expr : convert(e),


### PR DESCRIPTION
Hej,

Here is a minor fix when using hscript on compile-time (with hscript.Macro).
It comes form this issue : https://github.com/HaxeFoundation/hscript/issues/102
All what is done is replacing `#if hscriptPos` by `#if (!macro && hscriptPos)`.

The initial issue case test is the following : 
Main.hx : 
```haxe
class Main {
	static function main() {
		MyMacro.getExpr( "var x = 4; 1 + 2 * x" );
	}
}
class MyMacro{
	macro public static function getExpr( expr : String ){
		var pos	= haxe.macro.Context.currentPos();
		var parser	= new hscript.Parser();
		var ast	= parser.parseString( expr );
		return new hscript.Macro( pos ).convert( ast );
	}
}
```
build.hxml : 
```
-lib hscript
-D hscriptPos
-main Main
--interp
```