### PR TITLE
Add github CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,6 +22,13 @@ jobs:
     - name: Test interp
       run: |
         haxe bin/build-interp.hxml
+        haxe bin/build-interp.hxml -D hscriptPos
+    - name: Test neko
+      run: |
+        haxe bin/build-neko.hxml         && neko bin/Test.n
+    - name: Test js
+      run: |
+        haxe bin/build-js.hxml           && node bin/Test.js
     - name: Build hashlink from source
       run: |
         git clone https://github.com/HaxeFoundation/hashlink.git
@@ -31,4 +38,6 @@ jobs:
     - name: Test hl
       run: |
         haxe bin/build-hl.hxml           && ./hashlink/hl bin/Test.hl
+        
+
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,10 +25,12 @@ jobs:
         haxe bin/build-interp.hxml -D hscriptPos
     - name: Test neko
       run: |
-        haxe bin/build-neko.hxml         && neko bin/Test.n
+        haxe bin/build-neko.hxml               && neko bin/Test.n
+        haxe bin/build-neko.hxml -D hscriptPos && neko bin/Test.n
     - name: Test js
       run: |
-        haxe bin/build-js.hxml           && node bin/Test.js
+        haxe bin/build-js.hxml               && node bin/Test.js
+        haxe bin/build-js.hxml -D hscriptPos && node bin/Test.js
     - name: Build hashlink from source
       run: |
         git clone https://github.com/HaxeFoundation/hashlink.git
@@ -37,4 +39,5 @@ jobs:
         cd ..
     - name: Test hl
       run: |
-        haxe bin/build-hl.hxml           && ./hashlink/hl bin/Test.hl
+        haxe bin/build-hl.hxml               && ./hashlink/hl bin/Test.hl
+        haxe bin/build-hl.hxml -D hscriptPos && ./hashlink/hl bin/Test.hl

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,8 +13,9 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: krdlab/setup-haxe@v1
-    - name: Install haxelib hscript
+    - name: Install haxelib dependencies
       run: |
+        haxelib install hx3compat
         haxelib dev hscript .
     - name: Test interp
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,10 +20,12 @@ jobs:
     - name: Test interp
       run: |
         haxe bin/build-interp.hxml
-    - name: Install hashlink
+    - name: Build hashlink from source
       run: |
         git clone https://github.com/HaxeFoundation/hashlink.git
-        cd hashlink && make hl
+        cd hashlink
+        make hl
+        cd ..
     - name: Test hl
       run: |
         haxe bin/build-hl.hxml           && ./hashlink/hl bin/Test.hl

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: krdlab/setup-haxe@v1
+      with:
+          haxe-version: 4.3.4
     - name: Install haxelib dependencies
       run: |
         haxelib install hx3compat

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,6 +38,3 @@ jobs:
     - name: Test hl
       run: |
         haxe bin/build-hl.hxml           && ./hashlink/hl bin/Test.hl
-        
-
-

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  push:
+    # This should disable running the workflow on tags
+    branches:
+      - "**"
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: krdlab/setup-haxe@v1
+    - name: Install haxelib hscript
+      run: |
+        haxelib dev hscript .
+    - name: Test interp
+      run: |
+        haxe bin/build-interp.hxml
+    - name: Install hashlink
+      run: |
+        git clone https://github.com/HaxeFoundation/hashlink.git
+        cd hashlink && make hl
+    - name: Test hl
+      run: |
+        haxe bin/build-hl.hxml           && ./hashlink/hl bin/Test.hl
+

--- a/bin/build-hl.hxml
+++ b/bin/build-hl.hxml
@@ -1,0 +1,2 @@
+bin/build-each.hxml
+-hl bin/Test.hl


### PR DESCRIPTION
Add github CI that test for: interp, neko, js, hashlink. Using haxe 4.3.4 version, hashlink git master.
The run with github action is available on my fork.

Perhaps it can replace the appveyor/travisCI?