### PR TITLE
Add support for null safe field access

### DIFF
--- a/TestHScript.hx
+++ b/TestHScript.hx
@@ -115,6 +115,22 @@ class TestHScript extends TestCase {
 		assertScript("var a = 10; var b = 5; a - b / 2", 7.5);
 	}
 
+	function testNullFieldAccess():Void {
+		var pt = {x : 10};
+		var vars = {
+			ptnull : null,
+			pt: pt,
+			pt2null : {pt : null},
+			pt2: {pt : pt}
+		}
+		assertScript("ptnull?.x", null, vars);
+		assertScript("pt?.x", 10, vars);
+		assertScript("pt2null?.pt", null, vars);
+		assertScript("pt2null?.pt?.x", null, vars);
+		assertScript("pt2?.pt", pt, vars);
+		assertScript("pt2?.pt?.x", 10, vars);
+	}
+
 	function testMap():Void {
 		var objKey = { ok:true };
 		var vars = {

--- a/hscript/Parser.hx
+++ b/hscript/Parser.hx
@@ -815,7 +815,12 @@ class Parser {
 		case TQuestion:
 			if( maybe(TDot) ) {
 				var field = getIdent();
-				return parseExprNext(mk(ETernary(EBinop("==",e1,EIdent("null")),EIdent("null"),EField(e1,field)),pmin(e1)));
+				return parseExprNext(
+					mk(ETernary(
+						mk(EBinop("==",e1,mk(EIdent("null"),pmin(e1),pmax(e1)))),
+						mk(EIdent("null"),pmin(e1),pmax(e1)),
+						mk(EField(e1,field),pmin(e1))
+					),pmin(e1)));
 			}
 			var e2 = parseExpr();
 			ensure(TDoubleDot);

--- a/hscript/Parser.hx
+++ b/hscript/Parser.hx
@@ -813,6 +813,10 @@ class Parser {
 			ensure(TBkClose);
 			return parseExprNext(mk(EArray(e1,e2),pmin(e1)));
 		case TQuestion:
+			if( maybe(TDot) ) {
+				var field = getIdent();
+				return parseExprNext(mk(ETernary(EBinop("==", e1, EIdent("null")),EIdent("null"),EField(e1,field)),pmin(e1)));
+			}
 			var e2 = parseExpr();
 			ensure(TDoubleDot);
 			var e3 = parseExpr();

--- a/hscript/Parser.hx
+++ b/hscript/Parser.hx
@@ -815,7 +815,7 @@ class Parser {
 		case TQuestion:
 			if( maybe(TDot) ) {
 				var field = getIdent();
-				return parseExprNext(mk(ETernary(EBinop("==", e1, EIdent("null")),EIdent("null"),EField(e1,field)),pmin(e1)));
+				return parseExprNext(mk(ETernary(EBinop("==",e1,EIdent("null")),EIdent("null"),EField(e1,field)),pmin(e1)));
 			}
 			var e2 = parseExpr();
 			ensure(TDoubleDot);


### PR DESCRIPTION
For syntax: `pt?.x`.