### PR TITLE
Add `final` keyword

### DIFF
--- a/TestHScript.hx
+++ b/TestHScript.hx
@@ -113,6 +113,9 @@ class TestHScript extends TestCase {
 		assertScript("var f:(x:Int)->(Int, Int)->Int = (x:Int) -> (y:Int, z:Int) -> x + y + z; f(3)(1, 2)", 6, null, true);
 		assertScript("var a = 10; var b = 5; a - -b", 15);
 		assertScript("var a = 10; var b = 5; a - b / 2", 7.5);
+		assertScript("final a = 10; a", 10);
+		assertScript("final a, b; a", null);
+		assertScript("final a, b; b", null);
 	}
 
 	function testNullFieldAccess():Void {

--- a/hscript/Parser.hx
+++ b/hscript/Parser.hx
@@ -609,7 +609,7 @@ class Parser {
 				if( semic ) push(TSemicolon);
 			}
 			mk(EIf(cond,e1,e2),p1,(e2 == null) ? tokenMax : pmax(e2));
-		case "var":
+		case "var", "final":
 			var ident = getIdent();
 			var tk = token();
 			var t = null;
@@ -998,7 +998,7 @@ class Parser {
 				t = token();
 				switch( t ) {
 				case TBrClose: break;
-				case TId("var"):
+				case TId("var"), TId("final"):
 					var name = getIdent();
 					ensure(TDoubleDot);
 					fields.push( { name : name, t : parseType(), meta : meta } );
@@ -1232,7 +1232,7 @@ class Parser {
 						ret : inf.ret,
 					}),
 				};
-			case "var":
+			case "var", "final":
 				var name = getIdent();
 				var get = null, set = null;
 				if( maybe(TPOpen) ) {


### PR DESCRIPTION
It just acts like a variable, because wouldn't make sense to throw an error if it gets modified.
Requested in #78