### PR TITLE
Fix 1e5, 1e-5 evaluated as Infinity

### DIFF
--- a/TestHScript.hx
+++ b/TestHScript.hx
@@ -49,6 +49,10 @@ class TestHScript extends TestCase {
 		assertScript("- 123",-123);
 		assertScript("1.546",1.546);
 		assertScript(".545",.545);
+		assertScript("1e5",100000);
+		assertScript("1.2e2",120);
+		assertScript("100e-2",1);
+		assertScript("1.2e-1",0.12);
 		assertScript("'bla'","bla");
 		assertScript("null",null);
 		assertScript("true",true);

--- a/hscript/Parser.hx
+++ b/hscript/Parser.hx
@@ -1393,6 +1393,8 @@ class Parser {
 						}
 						if( pow == null )
 							invalidChar(char);
+						if( exp == 0 )
+							exp = 10;
 						return TConst(CFloat((Math.pow(10, pow) / exp) * n * 10));
 					case ".".code:
 						if( exp > 0 ) {


### PR DESCRIPTION
Previously `1e5`, `1e-5` are evaluated as `EConst(CFloat(Infinity))`, caused by division by exp (which is 0).

https://github.com/HaxeFoundation/hscript/blob/df4d43af41f5d0f768d1e10074d380507adce429/hscript/Parser.hx#L1396

