### PR TITLE
[CI] Fix JS with hscriptPos error

### DIFF
--- a/hscript/JsInterp.hx
+++ b/hscript/JsInterp.hx
@@ -80,7 +80,7 @@ class JsInterp extends Interp {
 		#if hscriptPos
 		var expr = curExpr;
 		var p = '{pmin:,pmax:,origin:"",line:}';
-		return '($$i._p(${expr.pmin},${expr.pmax},null,${expr.line}),$estr)';
+		return '($$i._p(${expr.pmin},${expr.pmax},"${expr.origin}",${expr.line}),$estr)';
 		#else
 		return estr;
 		#end

--- a/hscript/JsInterp.hx
+++ b/hscript/JsInterp.hx
@@ -80,7 +80,7 @@ class JsInterp extends Interp {
 		#if hscriptPos
 		var expr = curExpr;
 		var p = '{pmin:,pmax:,origin:"",line:}';
-		return '($$i._p(${expr.pmin},${expr.pmax},${expr.origin},${expr.line}),$estr)';
+		return '($$i._p(${expr.pmin},${expr.pmax},null,${expr.line}),$estr)';
 		#else
 		return estr;
 		#end


### PR DESCRIPTION
I don't know how exactly this hscriptPos work, but CI error with `ReferenceError: hscript is not defined` on `($i._p(0,0,hscript,3))` when running `haxe bin/build-js.hxml -D hscriptPos && node bin/Test.js`