### PR TITLE
Add support for class renaming via `as` keyword

### DIFF
--- a/hscript/Expr.hx
+++ b/hscript/Expr.hx
@@ -119,7 +119,7 @@ enum Error {
 
 enum ModuleDecl {
 	DPackage( path : Array<String> );
-	DImport( path : Array<String>, ?everything : Bool );
+	DImport( path : Array<String>, ?everything : Bool, ?name : String );
 	DClass( c : ClassDecl );
 	DTypedef( c : TypeDecl );
 }

--- a/hscript/Parser.hx
+++ b/hscript/Parser.hx
@@ -1139,8 +1139,18 @@ class Parser {
 					unexpected(t);
 				}
 			}
+			var name = path[path.length - 1];
+			if ( maybe(TId("as")) ) {
+				var t = token();
+				switch( t ) {
+				case TId(id):
+					name = id;
+				default:
+					unexpected(t);
+				}
+			}
 			ensure(TSemicolon);
-			return DImport(path, star);
+			return DImport(path, star, name);
 		case "class":
 			var name = getIdent();
 			var params = parseParams();

--- a/hscript/Parser.hx
+++ b/hscript/Parser.hx
@@ -1139,8 +1139,8 @@ class Parser {
 					unexpected(t);
 				}
 			}
-			var name = path[path.length - 1];
-			if ( maybe(TId("as")) ) {
+			var name = null;
+			if ( maybe(TId("as")) && !star) {
 				var t = token();
 				switch( t ) {
 				case TId(id):


### PR DESCRIPTION
When importing a class like `import [class] as [name];`, the script failed to run because a semicolon is expected at the end after the class itself. This Pull Request adds support for the keyword `as` so that multiple classes with the same name may be imported, while labelling them with different names to prevent class name collisions. 