### PR TITLE
Do not allow arrays without comma between values

### DIFF
--- a/hscript/Parser.hx
+++ b/hscript/Parser.hx
@@ -446,12 +446,18 @@ class Parser {
 		case TBkOpen:
 			var a = new Array();
 			tk = token();
+			var first = true;
 			while( tk != TBkClose && (!resumeErrors || tk != TEof) ) {
+				if (!first) {
+					if (tk != TComma)
+						unexpected(tk);
+					else
+						tk = token();
+				}
+				first = false;
 				push(tk);
 				a.push(parseExpr());
 				tk = token();
-				if( tk == TComma )
-					tk = token();
 			}
 			if( a.length == 1 && a[0] != null )
 				switch( expr(a[0]) ) {


### PR DESCRIPTION
When playing with hscript, I noticed that the parser accepts this array without any comma as value separator:

```hx
var list = [ "carrot" 1234 null "potato" ];
```

I don't know if it is an oversight or if it's on purpose, but in my case I needed to forbid it, so here is a pull request of that change.

After the change, the same array needs to be declared like this:

```hx
var list = [ "carrot", 1234, null, "potato" ];
```

Feel free to merge or close that pull request, depending on whether this is intentional or not!