### PR TITLE
check `EForGen` in `isBlock`

### DIFF
--- a/hscript/Parser.hx
+++ b/hscript/Parser.hx
@@ -273,7 +273,7 @@ class Parser {
 		case EUnop(_,prefix,e): !prefix && isBlock(e);
 		case EWhile(_,e): isBlock(e);
 		case EDoWhile(_,e): isBlock(e);
-		case EFor(_,_,e): isBlock(e);
+		case EFor(_,_,e), EForGen(_, e): isBlock(e);
 		case EReturn(e): e != null && isBlock(e);
 		case ETry(_, _, _, e): isBlock(e);
 		case EMeta(_, _, e): isBlock(e);


### PR DESCRIPTION
Semicolon should not be required for `EForGen` with `EBlock`.

```haxe
new hscript.Parser().parseString('
	for(key => value in map){
		trace(key + " " + value);
	}

	a();
'));
```
`Uncaught exception: hscript:7: Unexpected token: "a"`