### PR TITLE
add `default` to enum switches

### DIFF
--- a/hscript/Interp.hx
+++ b/hscript/Interp.hx
@@ -542,7 +542,10 @@ class Interp {
 			return expr(e);
 		case ECheckType(e,_):
 			return expr(e);
+		#if hscript_extraExprs
 		default:
+			throw '$e is unknown';
+		#end
 		}
 		return null;
 	}

--- a/hscript/Interp.hx
+++ b/hscript/Interp.hx
@@ -542,6 +542,7 @@ class Interp {
 			return expr(e);
 		case ECheckType(e,_):
 			return expr(e);
+		default:
 		}
 		return null;
 	}

--- a/hscript/Printer.hx
+++ b/hscript/Printer.hx
@@ -332,8 +332,10 @@ class Printer {
 			add(" : ");
 			addType(t);
 			add(")");
+		#if hscript_extraExprs
 		default:
-			add("???");
+			throw '${#if hscriptPos e.e #else e #end} is unknown';
+		#end
 		}
 	}
 

--- a/hscript/Printer.hx
+++ b/hscript/Printer.hx
@@ -332,6 +332,8 @@ class Printer {
 			add(" : ");
 			addType(t);
 			add(")");
+		default:
+			add("???");
 		}
 	}
 

--- a/hscript/Tools.hx
+++ b/hscript/Tools.hx
@@ -58,6 +58,7 @@ class Tools {
 			if( def != null ) f(def);
 		case EMeta(name, args, e): if( args != null ) for( a in args ) f(a); f(e);
 		case ECheckType(e,_): f(e);
+		default: null;
 		}
 	}
 
@@ -88,6 +89,7 @@ class Tools {
 		case ESwitch(e, cases, def): ESwitch(f(e), [for( c in cases ) { values : [for( v in c.values ) f(v)], expr : f(c.expr) } ], def == null ? null : f(def));
 		case EMeta(name, args, e): EMeta(name, args == null ? null : [for( a in args ) f(a)], f(e));
 		case ECheckType(e,t): ECheckType(f(e), t);
+		default: null;
 		}
 		return mk(edef, e);
 	}

--- a/hscript/Tools.hx
+++ b/hscript/Tools.hx
@@ -58,7 +58,10 @@ class Tools {
 			if( def != null ) f(def);
 		case EMeta(name, args, e): if( args != null ) for( a in args ) f(a); f(e);
 		case ECheckType(e,_): f(e);
-		default: null;
+		#if hscript_extraExprs
+		default:
+			throw '${expr(e)} is unknown';
+		#end
 		}
 	}
 


### PR DESCRIPTION
This PR adds a default to all `Expr` switches, so that libraries that try to add an extra `enum` entry with macros don't run into errors.