### PR TITLE
Restore compatibility with haxe prior to 4.1

### DIFF
--- a/hscript/Interp.hx
+++ b/hscript/Interp.hx
@@ -657,6 +657,8 @@ class Interp {
 			isAllObject = isAllObject && Reflect.isObject(key);
 			isAllEnum = isAllEnum && Reflect.isEnumValue(key);
 		}
+		
+		#if (haxe_ver >= 4.1)
 		if( isAllInt ) {
 			var m = new Map<Int,Dynamic>();
 			for( i => key in keys )
@@ -681,6 +683,20 @@ class Interp {
 				m.set(key, values[i]);
 			return m;
 		}
+		#else
+		var m:Dynamic = {
+			if ( isAllInt ) new haxe.ds.IntMap<Dynamic>();
+			else if ( isAllString ) new haxe.ds.StringMap<Dynamic>();
+			else if ( isAllEnum ) new haxe.ds.EnumValueMap<Dynamic, Dynamic>();
+			else if ( isAllObject ) new haxe.ds.ObjectMap<Dynamic, Dynamic>();
+			else null;
+		}
+		if( m != null ) {
+			for ( n in 0...keys.length )
+				setMapValue(m, keys[n], values[n]);
+			return m;
+		}
+		#end
 		error(ECustom("Invalid map keys "+keys));
 		return null;
 	}


### PR DESCRIPTION
Commit e2f607264220b54790a026577fb0534b94c93f75 broke compatibility with haxe versions prior to 4.1, as the `for` loops used in the `makeMap` function rely on the `keys` array to support `ArrayKeyValueIterator`, a [feature introduced in haxe 4.1](https://github.com/HaxeFoundation/haxe/commit/80638bec2b8f44b0c18572385a409f84b5713df7).

hscript documentation does not specify any requirement regarding a minimum haxe version. I know haxe 4.0.X is quite old, but some projects still rely on it. 

As such, I restored the "old code" prior to the breaking commit, while integrating it within the` makeMap` function, in between `#if (haxe >= 4.1)` guards. With this fix, hscript does compile with haxe 4.02 and 4.0.3 (not tested with other versions).