### PR TITLE
JSInterp: fix switch instruction with condition inside it's branches

### DIFF
--- a/TestHScript.hx
+++ b/TestHScript.hx
@@ -134,6 +134,10 @@ class TestHScript extends TestCase {
 		assertScript("false && xxx", false);
 		assertScript("true || xxx", true);
 		assertScript("[for( x in arr ) switch( x ) { case 1: 55; case 3: 66; default: 0; }].join(':')",'55:0:66',{ arr : [1,2,3] });
+		assertScript("switch( x ) { case 1: 55; case 3: 66; default: 0; }",66 ,{ x : 3 });
+		assertScript("var a = 1; switch( b ) { default: a = 2; }; a", 2, { b : 2 });
+		assertScript("var a = 1; switch( b ) { case 2: a = 100; default: a = 2; }; a", 100, { b : 2 });
+		assertScript("var a = 3; switch( b ) { case 2: if (a == 1) { a = 100; } else { a = 99; }; default: a = 2; }; a", 99, { b : 2 });
 	}
 
 	function testNullFieldAccess():Void {

--- a/hscript/JsInterp.hx
+++ b/hscript/JsInterp.hx
@@ -275,7 +275,7 @@ class JsInterp extends Interp {
 		case EIf(cond,e1,e2):
 			return 'if( ${exprCond(cond)} ) ${exprJS(e1)}'+(e2 == null ? "" : 'else ${exprJS(e2)}');
 		case ETernary(cond, e1, e2):
-			return '(${exprCond(cond)} ? ${exprValue(e1)} : ${exprValue(e2)})';
+			return '(${exprCond(cond)} ? ${exprValue(e1)} : ${e2 == null ? 'undefined' : exprValue(e2)})';
 		case EWhile(cond, e):
 			return 'while( ${exprValue(cond)} ) ${exprJS(e)}';
 		case EFor(v, it, e):


### PR DESCRIPTION
Fix null access when trying to use `JSInterp` while interpreting code that contains a switch case with a condition and no other instructions (see example below)

```
var t = 0;

// OK
switch {
    default:
        if (true)
            t = 1;
        t = 2;
}

// Crash
switch {
    default:
        if (true)
            t = 1;
}
```