### PR TITLE
Fix null safe field access for pt?.sub.x, pt?.call()

### DIFF
--- a/TestHScript.hx
+++ b/TestHScript.hx
@@ -141,7 +141,10 @@ class TestHScript extends TestCase {
 	}
 
 	function testNullFieldAccess():Void {
-		var pt = {x : 10};
+		var pt = {
+			x : 10,
+			call : function() { return 11; }
+		};
 		var vars = {
 			ptnull : null,
 			pt: pt,
@@ -149,11 +152,16 @@ class TestHScript extends TestCase {
 			pt2: {pt : pt}
 		}
 		assertScript("ptnull?.x", null, vars);
+		assertScript("ptnull?.pt.x", null, vars);
+		assertScript("ptnull?.call()", null, vars);
 		assertScript("pt?.x", 10, vars);
+		assertScript("pt?.call()", 11, vars);
 		assertScript("pt2null?.pt", null, vars);
 		assertScript("pt2null?.pt?.x", null, vars);
+		assertScript("pt2null?.pt?.call()", null, vars);
 		assertScript("pt2?.pt", pt, vars);
 		assertScript("pt2?.pt?.x", 10, vars);
+		assertScript("pt2?.pt?.call()", 11, vars);
 	}
 
 	function testIsOperator():Void {

--- a/hscript/Parser.hx
+++ b/hscript/Parser.hx
@@ -865,17 +865,18 @@ class Parser {
 			var field = getIdent();
 			return parseExprNext(mk(EField(e1,field),pmin(e1)));
 		case TQuestionDot:
-			var field = getIdent();
 			var tmp = "__a_" + (uid++);
+			push(TDot);
+			var e2 = parseExprNext(mk(EIdent(tmp),pmin(e1),pmax(e1)));
 			var e = mk(EBlock([
 				mk(EVar(tmp, null, e1), pmin(e1), pmax(e1)),
 				mk(ETernary(
 					mk(EBinop("==", mk(EIdent(tmp),pmin(e1),pmax(e1)), mk(EIdent("null"),pmin(e1),pmax(e1)))),
 					mk(EIdent("null"),pmin(e1),pmax(e1)),
-					mk(EField(mk(EIdent(tmp),pmin(e1),pmax(e1)),field),pmin(e1))
+					e2,
 				))
 			]),pmin(e1));
-			return parseExprNext(e);
+			return e;
 		case TPOpen:
 			return parseExprNext(mk(ECall(e1,parseExprList(TPClose)),pmin(e1)));
 		case TBkOpen:


### PR DESCRIPTION
See https://github.com/HaxeFoundation/hscript/pull/127#issuecomment-3558990367