### PR TITLE
added string interpolation support

### DIFF
--- a/TestHScript.hx
+++ b/TestHScript.hx
@@ -252,6 +252,14 @@ class TestHScript extends TestCase {
 		assertScript('var newMap = [{a:"a"}=>"foo", objKey=>"bar"]; newMap[objKey];', 'bar', vars);
 	}
 
+	function testStringInterpolation():Void {
+		assertScript("var a = 5; 'a is ${a}'", 'a is 5');
+		assertScript("var a = 5; 'a is ${a + 1}'", 'a is 6');
+		assertScript("var a = 5; 'a is ${if (a > 3) \"big\" else \"small\"}'", 'a is big');
+		assertScript("var a = 5; 'a is ${switch (a) { case 0: \"zero\"; case 5: \"five\"; default: \"other\"; }}'", 'a is five');
+		assertScript("'Hello, ${{var val = false; if (val) \"world\" else {var num = 5 + 3; 'userid_${num}';}}}!'", 'Hello, userid_8!');
+	}
+
 	static function main() {
 		#if ((haxe_ver < 4) && php)
 		// uncaught exception: The each() function is deprecated. This message will be suppressed on further calls (errno: 8192)

--- a/hscript/Expr.hx
+++ b/hscript/Expr.hx
@@ -21,10 +21,15 @@
  */
 package hscript;
 
+enum StringKind {
+	DoubleQuotes;
+	SingleQuotes;
+}
+
 enum Const {
 	CInt( v : Int );
 	CFloat( f : Float );
-	CString( s : String );
+	CString( s : String , ?kind : StringKind);
 }
 
 #if hscriptPos

--- a/hscript/Parser.hx
+++ b/hscript/Parser.hx
@@ -751,20 +751,20 @@ class Parser {
 					{
 						if (brOpens == -1)
 							unexpected(tk);
-						if (brOpens == 0)
-							break;
 						brOpens--;
+						if (brOpens <= 0)
+							break;
 					}
-					if( tk == TEof ) break;
+					if( tk == TEof )
+						error(EUnterminatedString, currentPos, currentPos);
 				}
 				var endPos = readPos - 1;
 				reset();
 				input = s.substring(i, endPos) + ";}";
+				readPos = 0;
 				var a = new Array();
 				while( true ) {
 					var tk = token();
-					if (readPos >= endPos)
-						break;
 					if( tk == TEof ) break;
 					push(tk);
 					parseFullExpr(a);
@@ -773,7 +773,7 @@ class Parser {
 				ex.push(mk(EBlock(a),0));
 				nextStr = "";
 				input = lastInput;
-				i = readPos;
+				i = endPos + 1;
 				c = s.charCodeAt(i);
 				readPos = lastReadPos;
 				char = lastChar;

--- a/hscript/Parser.hx
+++ b/hscript/Parser.hx
@@ -354,6 +354,21 @@ class Parser {
 				e = mk(EIdent(id));
 			return isBlock(e) ? e : parseExprNext(e);
 		case TConst(c):
+			if (c.match(CString(_, SingleQuotes)))
+			{
+				var ex = makeInterpolatedStr(tk);
+				if (ex.length == 1)
+					return parseExprNext(ex[0]);
+				else
+				{
+					var result = ex[0];
+					for (i in 1...ex.length)
+					{
+						result = makeBinop("+", result, ex[i]);
+					}
+					return parseExprNext(mk(EParent(result), p1));
+				}
+			}
 			return parseExprNext(mk(EConst(c)));
 		case TPOpen:
 			tk = token();
@@ -642,6 +657,115 @@ class Parser {
 		default:
 			mk(EBinop(op,e1,e),pmin(e1),pmax(e));
 		}
+	}
+
+	function makeInterpolatedStr(tk:Token):Array<Expr> {
+		var ex = new Array();
+		var s = switch(tk)
+		{
+		case TConst(c):
+			switch(c)
+			{
+			case CString(s):
+				s;
+			case _:
+				null;
+			}
+		case _:
+			null;
+		}
+
+		if (s == null)
+			error(ECustom("Invalid string literal"), tokenMin, tokenMax);
+
+		var nextStr = "";
+
+		var i = 0;
+		var c = s.charCodeAt(i);
+		while (true)
+		{
+			if (StringTools.isEof(c))
+			{
+				ex.push(mk(EConst(CString(nextStr)), tokenMin, tokenMax));
+				break;
+			}
+
+			if (c != "$".code)
+			{
+				nextStr += String.fromCharCode(c);
+				c = s.charCodeAt(++i);
+				continue;
+			}
+
+			c = s.charCodeAt(++i);
+			if (c >= 48 && c <= 57 || c == "$".code)
+			{
+				nextStr += "$" + String.fromCharCode(c);
+				c = s.charCodeAt(++i);
+				continue;
+			}
+
+			if( idents[c] ) {
+				var id = String.fromCharCode(c);
+				while( true ) {
+					c = s.charCodeAt(++i);
+					if( StringTools.isEof(c) ) c = 0;
+					if( !idents[c] ) {
+						break;
+					}
+					id += String.fromCharCode(c);
+				}
+				ex.push(mk(EConst(CString(nextStr)), tokenMin, tokenMax));
+				ex.push(mk(EIdent(id), tokenMin, tokenMax));
+				nextStr = "";
+			}
+			else if (c == "{".code)
+			{
+				var lastInput = input;
+				var lastReadPos = readPos;
+				var lastChar = char;
+				var lastTokens = tokens;
+				input = s;
+				readPos = i + 1;
+				char = -1;
+				#if hscriptPos
+				tokens = new List();
+				#else
+				tokens = new haxe.ds.GenericStack<Token>();
+				#end
+				var a = new Array();
+				var brOpens = 0;
+				while( true ) {
+					var tk = token();
+					if ( tk == TBrOpen )
+						brOpens++;
+					else if ( tk == TBrClose )
+					{
+						if (brOpens == 0)
+							break;
+						brOpens--;
+					}
+					if( tk == TEof ) break;
+					push(tk);
+					parseFullExpr(a);
+				}
+				ex.push(mk(EConst(CString(nextStr)), tokenMin, tokenMax));
+				ex.push(mk(EBlock(a),0));
+				nextStr = "";
+				input = lastInput;
+				i = readPos;
+				c = s.charCodeAt(i);
+				readPos = lastReadPos;
+				char = lastChar;
+				tokens = lastTokens;
+			}
+			else
+			{
+				nextStr += "$";
+				i--;
+			}
+		}
+		return ex;
 	}
 
 	function parseStructure(id) {
@@ -1589,7 +1713,8 @@ class Parser {
 			case "}".code: return TBrClose;
 			case "[".code: return TBkOpen;
 			case "]".code: return TBkClose;
-			case "'".code, '"'.code: return TConst( CString(readString(char)) );
+			case "'".code: return TConst( CString(readString(char), SingleQuotes) );
+			case '"'.code: return TConst( CString(readString(char), DoubleQuotes) );
 			case "?".code:
 				char = readChar();
 				if( char == ".".code )

--- a/hscript/Parser.hx
+++ b/hscript/Parser.hx
@@ -670,7 +670,7 @@ class Parser {
 		}
 
 		var i = 0;
-		var c = s.charCodeAt(i);
+		var c = StringTools.fastCodeAt(s, i);
 		while (true)
 		{
 			if (StringTools.isEof(c))
@@ -682,22 +682,22 @@ class Parser {
 			if (c != "$".code)
 			{
 				nextStr += String.fromCharCode(c);
-				c = s.charCodeAt(++i);
+				c = StringTools.fastCodeAt(s, ++i);
 				continue;
 			}
 
-			c = s.charCodeAt(++i);
+			c = StringTools.fastCodeAt(s, ++i);
 			if (c >= 48 && c <= 57 || c == "$".code)
 			{
 				nextStr += "$" + String.fromCharCode(c);
-				c = s.charCodeAt(++i);
+				c = StringTools.fastCodeAt(s, ++i);
 				continue;
 			}
 
 			if( idents[c] ) {
 				var id = String.fromCharCode(c);
 				while( true ) {
-					c = s.charCodeAt(++i);
+					c = StringTools.fastCodeAt(s, ++i);
 					if( StringTools.isEof(c) ) c = 0;
 					if( !idents[c] ) {
 						break;
@@ -766,7 +766,7 @@ class Parser {
 				nextStr = "";
 				input = lastInput;
 				i = endPos + 1;
-				c = s.charCodeAt(i);
+				c = StringTools.fastCodeAt(s, i);
 				readPos = lastReadPos;
 				char = lastChar;
 				tokens = lastTokens;

--- a/hscript/Parser.hx
+++ b/hscript/Parser.hx
@@ -363,9 +363,7 @@ class Parser {
 				{
 					var result = ex[0];
 					for (i in 1...ex.length)
-					{
 						result = makeBinop("+", result, ex[i]);
-					}
 					return parseExprNext(mk(EParent(result), p1));
 				}
 			}
@@ -679,6 +677,12 @@ class Parser {
 			error(ECustom("Invalid string literal"), tokenMin, tokenMax);
 
 		var nextStr = "";
+		function pushNextStr() {
+			if (nextStr != "") {
+				ex.push(mk(EConst(CString(nextStr)), tokenMin, tokenMax));
+				nextStr = "";
+			}
+		}
 
 		var i = 0;
 		var c = s.charCodeAt(i);
@@ -686,7 +690,7 @@ class Parser {
 		{
 			if (StringTools.isEof(c))
 			{
-				ex.push(mk(EConst(CString(nextStr)), tokenMin, tokenMax));
+				pushNextStr();
 				break;
 			}
 
@@ -715,12 +719,14 @@ class Parser {
 					}
 					id += String.fromCharCode(c);
 				}
-				ex.push(mk(EConst(CString(nextStr)), tokenMin, tokenMax));
+				pushNextStr();
 				ex.push(mk(EIdent(id), tokenMin, tokenMax));
 				nextStr = "";
 			}
 			else if (c == "{".code)
 			{
+				pushNextStr();
+				nextStr = "";
 				var lastInput = input;
 				var lastReadPos = readPos;
 				var lastChar = char;
@@ -760,6 +766,7 @@ class Parser {
 				}
 				var endPos = readPos - 1;
 				reset();
+				// cool hack to quickly close expressions
 				input = s.substring(i, endPos) + ";}";
 				readPos = 0;
 				var a = new Array();
@@ -769,7 +776,7 @@ class Parser {
 					push(tk);
 					parseFullExpr(a);
 				}
-				ex.push(mk(EConst(CString(nextStr)), tokenMin, tokenMax));
+				pushNextStr();
 				ex.push(mk(EBlock(a),0));
 				nextStr = "";
 				input = lastInput;
@@ -782,7 +789,6 @@ class Parser {
 			else
 			{
 				nextStr += "$";
-				i--;
 			}
 		}
 		return ex;
@@ -1529,6 +1535,10 @@ class Parser {
 	inline function readChar() {
 		return StringTools.fastCodeAt(input, readPos++);
 	}
+	
+	inline function peekChar() {
+		return StringTools.fastCodeAt(input, readPos);
+	}
 
 	function readString( until ) {
 		var c = 0;
@@ -1582,7 +1592,36 @@ class Parser {
 				esc = true;
 			else if( c == until )
 				break;
-			else {
+			else if (c == '$'.code && peekChar() == '{'.code)
+			{
+				b.addChar('$'.code);
+				var brOpens = -1;
+				while (true)
+				{
+					c = readChar();
+					if (StringTools.isEof(c))
+					{
+						line = old;
+						error(EUnterminatedString, p1, p1);
+						break;
+					}
+					b.addChar(c);
+					if ( c == '{'.code )
+					{
+						if (brOpens == -1)
+							brOpens = 0;
+						brOpens++;
+					}
+					else if ( c == '}'.code )
+					{
+						if (brOpens == -1)
+							invalidChar(c);
+						brOpens--;
+						if (brOpens <= 0)
+							break;
+					}
+				}
+			} else {
 				if( c == 10 ) line++;
 				b.addChar(c);
 			}

--- a/hscript/Parser.hx
+++ b/hscript/Parser.hx
@@ -720,14 +720,25 @@ class Parser {
 				var lastReadPos = readPos;
 				var lastChar = char;
 				var lastTokens = tokens;
+				var lastOffset = offset;
+				var lastLine = line;
+				#if hscriptPos
+				var lastTokenMin = tokenMin;
+				var lastTokenMax = tokenMax;
+				var lastOldTokenMin = oldTokenMin;
+				var lastOldTokenMax = oldTokenMax;
+				#end
 
 				function reset()
 				{
 					input = s;
 					readPos = i;
 					char = -1;
+					offset = lastOffset;
 					#if hscriptPos
 					tokens = new List();
+					tokenMin = oldTokenMin = currentPos;
+					tokenMax = oldTokenMax = currentPos;
 					#else
 					tokens = new haxe.ds.GenericStack<Token>();
 					#end
@@ -755,8 +766,14 @@ class Parser {
 				}
 				var endPos = readPos - 1;
 				reset();
-				input = s.substring(++i, endPos);
+				var startPos = ++i;
+				input = s.substring(startPos, endPos);
 				readPos = 0;
+				offset = lastOffset + startPos;
+				#if hscriptPos
+				tokenMin = oldTokenMin = currentPos;
+				tokenMax = oldTokenMax = currentPos;
+				#end
 				var a = new Array();
 				while( true ) {
 					var tk = token();
@@ -773,6 +790,14 @@ class Parser {
 				readPos = lastReadPos;
 				char = lastChar;
 				tokens = lastTokens;
+				offset = lastOffset;
+				line = lastLine;
+				#if hscriptPos
+				tokenMin = lastTokenMin;
+				tokenMax = lastTokenMax;
+				oldTokenMin = lastOldTokenMin;
+				oldTokenMax = lastOldTokenMax;
+				#end
 			}
 			else
 			{

--- a/hscript/Parser.hx
+++ b/hscript/Parser.hx
@@ -690,7 +690,7 @@ class Parser {
 			}
 
 			c = StringTools.fastCodeAt(s, ++i);
-			if (c >= 48 && c <= 57 || c == "$".code)
+			if ((c >= "0".code && c <= "9".code) || c == "$".code)
 			{
 				nextStr.add("$");
 				nextStr.addChar(c);

--- a/hscript/Parser.hx
+++ b/hscript/Parser.hx
@@ -1528,7 +1528,7 @@ class Parser {
 		return StringTools.fastCodeAt(input, readPos);
 	}
 
-	function readString( until ) {
+	function readString( until , allowInterpolation = false ) {
 		var c = 0;
 		var b = new StringBuf();
 		var esc = false;
@@ -1580,7 +1580,7 @@ class Parser {
 				esc = true;
 			else if( c == until )
 				break;
-			else if (c == '$'.code && peekChar() == '{'.code)
+			else if (allowInterpolation && c == '$'.code && peekChar() == '{'.code)
 			{
 				b.addChar('$'.code);
 				var brOpens = -1;
@@ -1760,8 +1760,8 @@ class Parser {
 			case "}".code: return TBrClose;
 			case "[".code: return TBkOpen;
 			case "]".code: return TBkClose;
-			case "'".code: return TConst( CString(readString(char), SingleQuotes) );
-			case '"'.code: return TConst( CString(readString(char), DoubleQuotes) );
+			case "'".code: return TConst( CString(readString(char, true), SingleQuotes) );
+			case '"'.code: return TConst( CString(readString(char, false), DoubleQuotes) );
 			case "?".code:
 				char = readChar();
 				if( char == ".".code )

--- a/hscript/Parser.hx
+++ b/hscript/Parser.hx
@@ -755,8 +755,7 @@ class Parser {
 				}
 				var endPos = readPos - 1;
 				reset();
-				// cool hack to quickly close expressions
-				input = s.substring(i, endPos) + ";}";
+				input = s.substring(++i, endPos);
 				readPos = 0;
 				var a = new Array();
 				while( true ) {

--- a/hscript/Parser.hx
+++ b/hscript/Parser.hx
@@ -661,11 +661,14 @@ class Parser {
 	function makeInterpolatedStr(s:String):Array<Expr> {
 		var ex = new Array();
 
-		var nextStr = "";
+		inline function newBuf()
+			return new StringBuf();
+
+		var nextStr = newBuf();
 		function pushNextStr() {
-			if (nextStr != "") {
-				ex.push(mk(EConst(CString(nextStr)), tokenMin, tokenMax));
-				nextStr = "";
+			if (nextStr.length > 0) {
+				ex.push(mk(EConst(CString(nextStr.toString())), tokenMin, tokenMax));
+				nextStr = newBuf();
 			}
 		}
 
@@ -681,7 +684,7 @@ class Parser {
 
 			if (c != "$".code)
 			{
-				nextStr += String.fromCharCode(c);
+				nextStr.addChar(c);
 				c = StringTools.fastCodeAt(s, ++i);
 				continue;
 			}
@@ -689,7 +692,8 @@ class Parser {
 			c = StringTools.fastCodeAt(s, ++i);
 			if (c >= 48 && c <= 57 || c == "$".code)
 			{
-				nextStr += "$" + String.fromCharCode(c);
+				nextStr.add("$");
+				nextStr.addChar(c);
 				c = StringTools.fastCodeAt(s, ++i);
 				continue;
 			}
@@ -706,12 +710,12 @@ class Parser {
 				}
 				pushNextStr();
 				ex.push(mk(EIdent(id), tokenMin, tokenMax));
-				nextStr = "";
+				nextStr = newBuf();
 			}
 			else if (c == "{".code)
 			{
 				pushNextStr();
-				nextStr = "";
+				nextStr = newBuf();
 				var lastInput = input;
 				var lastReadPos = readPos;
 				var lastChar = char;
@@ -763,7 +767,7 @@ class Parser {
 				}
 				pushNextStr();
 				ex.push(mk(EBlock(a),0));
-				nextStr = "";
+				nextStr = newBuf();
 				input = lastInput;
 				i = endPos + 1;
 				c = StringTools.fastCodeAt(s, i);
@@ -773,7 +777,7 @@ class Parser {
 			}
 			else
 			{
-				nextStr += "$";
+				nextStr.add("$");
 			}
 		}
 		return ex;

--- a/hscript/Parser.hx
+++ b/hscript/Parser.hx
@@ -354,9 +354,9 @@ class Parser {
 				e = mk(EIdent(id));
 			return isBlock(e) ? e : parseExprNext(e);
 		case TConst(c):
-			if (c.match(CString(_, SingleQuotes)))
-			{
-				var ex = makeInterpolatedStr(tk);
+			switch( c ) {
+			case CString(s, SingleQuotes):
+				var ex = makeInterpolatedStr(s);
 				if (ex.length == 1)
 					return parseExprNext(ex[0]);
 				else
@@ -366,8 +366,9 @@ class Parser {
 						result = makeBinop("+", result, ex[i]);
 					return parseExprNext(mk(EParent(result), p1));
 				}
+			default:
+				return parseExprNext(mk(EConst(c)));
 			}
-			return parseExprNext(mk(EConst(c)));
 		case TPOpen:
 			tk = token();
 			if( tk == TPClose ) {
@@ -657,24 +658,8 @@ class Parser {
 		}
 	}
 
-	function makeInterpolatedStr(tk:Token):Array<Expr> {
+	function makeInterpolatedStr(s:String):Array<Expr> {
 		var ex = new Array();
-		var s = switch(tk)
-		{
-		case TConst(c):
-			switch(c)
-			{
-			case CString(s):
-				s;
-			case _:
-				null;
-			}
-		case _:
-			null;
-		}
-
-		if (s == null)
-			error(ECustom("Invalid string literal"), tokenMin, tokenMax);
 
 		var nextStr = "";
 		function pushNextStr() {

--- a/hscript/Parser.hx
+++ b/hscript/Parser.hx
@@ -725,26 +725,46 @@ class Parser {
 				var lastReadPos = readPos;
 				var lastChar = char;
 				var lastTokens = tokens;
-				input = s;
-				readPos = i + 1;
-				char = -1;
-				#if hscriptPos
-				tokens = new List();
-				#else
-				tokens = new haxe.ds.GenericStack<Token>();
-				#end
-				var a = new Array();
-				var brOpens = 0;
+
+				function reset()
+				{
+					input = s;
+					readPos = i;
+					char = -1;
+					#if hscriptPos
+					tokens = new List();
+					#else
+					tokens = new haxe.ds.GenericStack<Token>();
+					#end
+				}
+				reset();
+				var brOpens = -1;
 				while( true ) {
 					var tk = token();
 					if ( tk == TBrOpen )
+					{
+						if (brOpens == -1)
+							brOpens = 0;
 						brOpens++;
+					}
 					else if ( tk == TBrClose )
 					{
+						if (brOpens == -1)
+							unexpected(tk);
 						if (brOpens == 0)
 							break;
 						brOpens--;
 					}
+					if( tk == TEof ) break;
+				}
+				var endPos = readPos - 1;
+				reset();
+				input = s.substring(i, endPos) + ";}";
+				var a = new Array();
+				while( true ) {
+					var tk = token();
+					if (readPos >= endPos)
+						break;
 					if( tk == TEof ) break;
 					push(tk);
 					parseFullExpr(a);


### PR DESCRIPTION
Yes, I'm aware that https://github.com/HaxeFoundation/hscript/pull/62 exists, however, that PR had some bugs, was missing features (notably interpolation with block expressions), and appears to have been abandoned, so I've opened this PR to properly implement string interpolation in hscript to replicate the original behavior as closely as possible.
Don't get me wrong, @DleanJeans did a great job with the initial implementation; it just had a few quirks I wanted to fix. My intention was never to overshadow the original work.

(Also fixes https://github.com/HaxeFoundation/hscript/issues/61)